### PR TITLE
Fix text generation interface

### DIFF
--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -70,13 +70,6 @@ def entry_point_run_modalities(config_file_path: Path):
     help="Specify which Tokenizer (inheriting from transformers.PretrainedTokenizers) should get used.",
 )
 @click.option(
-    "--tokenizer_type",
-    type=TokenizerTypes,
-    show_default=True,
-    default=GPT2TokenizerFast,
-    help="Specify which Tokenizer (inheriting from transformers.PretrainedTokenizers) should get used.",
-)
-@click.option(
     "--tokenizer_file",
     type=Path,
     show_default=True,

--- a/src/modalities/utils/generate_text.py
+++ b/src/modalities/utils/generate_text.py
@@ -109,11 +109,11 @@ def main(model_path: Path, config_path: Path, tokenizer: PreTrainedTokenizer, ma
             if chat is True:
                 prompt = input("enter question> ").strip()
                 prompt = chat_prefix + chat_prompt_template.format(prompt=prompt)
-                generate(model, tokenizer, prompt, config.model.config.config.block_size, max_new_tokens)
+                generate(model, tokenizer, prompt, config.model.config.block_size, max_new_tokens)
             else:
                 prompt = input("enter prompt> ")
                 print(prompt, end="")
-                generate(model, tokenizer, prompt, config.model.config.config.block_size, max_new_tokens)
+                generate(model, tokenizer, prompt, config.model.config.block_size, max_new_tokens)
         except KeyboardInterrupt:
             print("closing app...")
             break


### PR DESCRIPTION
Text generation interface was broken due to faulty config paths and faulty command line arguments. 

I branched out of the minimal example branch (https://github.com/Modalities/modalities/tree/minimal_example), so we should merge that one first. 