### PR TITLE
fix: support opengptx data encoding

### DIFF
--- a/benchmarks/dataloader/README.md
+++ b/benchmarks/dataloader/README.md
@@ -1,0 +1,68 @@
+# Benchmarking of Dataset Implementations
+
+## Motivation
+We want to include a storage efficient, fast and generic dataset implementation in this repository.
+Previous work and ideas were based on MegatronLM and its dataset implementation.
+
+Unfortunately its usage is quite intransparent and causes regularly unexpected side effects.
+Those problems are hard to trace, as we are not the original authors of the code.
+
+Therefore we want to provide an own implementation, which comes with all the above mentioned benefits.
+Most importantly, it should be at least as fast as MegatronLM's implementation.
+
+
+## Benchmark Overview
+
+We want to evaluate multiple aspects of the dataset implementations:
+* preparation speed - All datasets need to do some initial steps like tokenization and indexing.
+* initialization speed - When firing up a respective `Dataset` object inside the code.
+* iteration speed - When accessing elements (in a random order) in the respective datasets
+
+
+## Used Example Dataset
+
+The experiments were conducted on a small sample of openwebtext. The data is provided in `.jsonl`-format.
+The relevant data included can be found under `"text"` and is obviously text-only.
+Each dataset with X samples refers to the first X lines in the full openwebtext data,
+ as it can be obtained from huggingface.
+
+
+## Experimental Setup
+
+We relied on the functions provided in `launch_benchmark.sh`. One can reproduce those by calling e.g.
+
+```shell
+. launch_benchmark.sh
+
+INPUT_DIR=<path-to-your-example-dataset.jsonl>
+
+echo "MegatronLM:"
+measure_megatronLM_iteration
+echo "Modalities:"
+measure_modalities_iteration
+```
+
+> For launching the preparation of MegatronLM's dataset, refer to:
+> https://github.com/OpenGPTX/opengptx_data/tree/docs/modalities-vs-megatronlm-dl and look at the `launch_benchmark.sh`
+> script.
+
+
+## Results
+
+
+| Evaluation Aspect    | Implementation | Required Time | # Samples in Data |
+|----------------------|----------------|---------------|-------------------|
+| preparation speed    | MegatronLM     | `0m16,965s`   | `20000(OWT)`      |
+| preparation speed    | Modalities     | `0m18,952s`   | `20000(OWT)`      |
+| preparation speed    | MegatronLM     | `2m11,856s`   | `200000(OWT)`     |
+| preparation speed    | Modalities     | `1m42,943s`   | `200000(OWT)`     |
+| initialization speed | MegatronLM     | `19.3 msec`   | `20000(OWT)`      |
+| initialization speed | Modalities     | `5.85 msec`   | `20000(OWT)`      |
+| initialization speed | MegatronLM     | `180 msec `   | `200000(OWT)`     |
+| initialization speed | Modalities     | `58 msec`     | `200000(OWT)`     |
+| iteration speed      | MegatronLM     | `52.4 msec`   | `20000(OWT)`      |
+| iteration speed      | Modalities     | `66.8 msec`   | `20000(OWT)`      | 
+| iteration speed      | MegatronLM     | `426 msec `   | `200000(OWT)`     |
+| iteration speed      | Modalities     | `545 msec`    | `200000(OWT)`     |
+
+

--- a/benchmarks/dataloader/launch_benchmark.sh
+++ b/benchmarks/dataloader/launch_benchmark.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+
+
+INPUT_DIR="/tmp/i-do-not-exist.jsonl"
+
+
+measure_modalities_preparation() {
+    time (
+        set -e
+        test -f $INPUT_DIR
+        rm -f ${INPUT_DIR/.jsonl/.idx}
+        modalities create_memmap_index $INPUT_DIR &> /dev/null
+        echo "finished memmap index creation"
+        rm -f ${INPUT_DIR/.jsonl/.pbin}
+        modalities create_packed_data $INPUT_DIR &> /dev/null
+        echo "finished memmap packing"
+    )
+}
+
+
+measure_modalities_initialization() {
+  input_file=${INPUT_DIR/.jsonl/.pbin}
+  python -m timeit -n 50 -r 5 -s "
+import sys, io
+null_device = io.StringIO()
+from modalities.dataloader.dataset import PackedMemMapDatasetMegatron
+from pathlib import Path
+p = Path(\"${input_file}\")
+  " -- "
+sys.stdout = null_device  # deactivate stdout to avoid getting spammed
+PackedMemMapDatasetMegatron(raw_data_path=p, block_size=1024, sample_key=\"sample\")
+sys.stdout = sys.__stdout__  # reactivate stdout for timeit
+"
+}
+
+measure_megatronLM_initialization() {
+  input_file="${INPUT_DIR/.jsonl/.megLM.bin_text_document}"
+  python -m timeit -n 50 -r 5 -s "
+import sys, io
+null_device = io.StringIO()
+from modalities.dataloader.open_gptx_dataset.mmap_dataset import MMapIndexedDataset
+p = \"${input_file}\"
+  " -- "
+sys.stdout = null_device  # deactivate stdout to avoid getting spammed
+MMapIndexedDataset(p)
+sys.stdout = sys.__stdout__  # reactivate stdout for timeit
+"
+}
+
+measure_modalities_iteration() {
+  input_file=${INPUT_DIR/.jsonl/.pbin}
+  python -m timeit -n 5 -r 3 -s "
+import random, sys, io
+null_device = io.StringIO()
+from modalities.dataloader.dataset import PackedMemMapDatasetMegatron
+from pathlib import Path
+p = Path(\"${input_file}\")
+sys.stdout = null_device  # deactivate stdout to avoid getting spammed
+dataset = PackedMemMapDatasetMegatron(raw_data_path=p, block_size=1024, sample_key=\"sample\")
+random_indices = random.sample(range(len(dataset)), len(dataset))
+sys.stdout = sys.__stdout__  # reactivate stdout for timeit
+  " -- "
+list(dataset)  # sequential access
+for i in random_indices:
+  dataset[i]
+"
+}
+
+
+measure_megatronLM_iteration() {
+  input_file="${INPUT_DIR/.jsonl/.megLM.bin_text_document}"
+  python -m timeit -n 5 -r 3 -s "
+import random, sys, io
+null_device = io.StringIO()
+from modalities.dataloader.open_gptx_dataset.mmap_dataset import MMapIndexedDataset
+p = \"${input_file}\"
+sys.stdout = null_device  # deactivate stdout to avoid getting spammed
+dataset = MMapIndexedDataset(p)
+random_indices = random.sample(range(len(dataset)), len(dataset))
+sys.stdout = sys.__stdout__  # reactivate stdout for timeit
+  " -- "
+list(dataset)  # sequential access
+for i in random_indices:
+  dataset[i]
+"
+}
+
+
+echo "MegatronLM:"
+measure_megatronLM_iteration
+echo "Modalities:"
+measure_modalities_iteration

--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import logging
+import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
@@ -137,7 +138,16 @@ def entry_point_create_memmap_index(src_path, index_path):
     default=".text",
     help="jq pattern to extract the data from the json line.",
 )
-def entry_point_create_packed_data(src_path, dst_path, index_path, tokenizer_type, tokenizer_file, jq_pattern):
+@click.option(
+    "--num-cpus",
+    type=int,
+    show_default=True,
+    default=os.cpu_count(),
+    help="Specify the number of tokenization workers. Default is the number of available CPUs.",
+)
+def entry_point_create_packed_data(
+    src_path, dst_path, index_path, tokenizer_type, tokenizer_file, jq_pattern, num_cpus
+):
     # TODO: if we want to use alternative entrypoints together with the ResolverRegistry,
     #  we can currently not rely on the existing class resolver.
     #  This is based on its connection to the overall `AppConfig`.
@@ -145,7 +155,9 @@ def entry_point_create_packed_data(src_path, dst_path, index_path, tokenizer_typ
     #  This could get resolved by implementing on own ResolverRegistry for each entrypoint or adapting the existing
     #  ResolverRegistry to work dynamically with any type-hinted config object from config.py.
     tokenizer = tokenizer_type.value(tokenizer_file=str(tokenizer_file))
-    generator = PackedDataGenerator(src_path, index_path=index_path, tokenizer=tokenizer, jq_pattern=jq_pattern)
+    generator = PackedDataGenerator(
+        src_path, index_path=index_path, tokenizer=tokenizer, jq_pattern=jq_pattern, number_of_processes=num_cpus
+    )
     generator.run(dst_path)
 
 

--- a/src/modalities/constants.py
+++ b/src/modalities/constants.py
@@ -1,0 +1,2 @@
+# Not relying on "utf8" after encountering encoding issues when using OpenGPT-X Data.
+DEFAULT_ENCODING = "iso-8859-1"

--- a/src/modalities/dataloader/dataset.py
+++ b/src/modalities/dataloader/dataset.py
@@ -161,7 +161,7 @@ class PackedMemMapDatasetMegatron(PackedMemMapDatasetBase):
         curr_len = 0
         block_size_in_bytes = self.block_size * self.INT_SIZE_IN_BYTES
         for segment_offset, segment_len in tqdm(self.index_base):
-            # When the sum of of the length of the current previously seen samples doesn't
+            # When the sum of the length of the current previously seen samples doesn't
             # exceed block_size_in_bytes, we add the current segment length to the previous
             # ones and continue.
             if curr_len + segment_len < block_size_in_bytes:

--- a/src/modalities/dataloader/large_file_lines_reader.py
+++ b/src/modalities/dataloader/large_file_lines_reader.py
@@ -6,6 +6,8 @@ from typing import List
 
 import numpy as np
 
+from modalities.constants import DEFAULT_ENCODING
+
 
 class BaseReader(ABC):
     @abstractmethod
@@ -60,7 +62,7 @@ class LargeFileLinesReader(BaseReader):
             try:
                 # TODO: verify why iso-8859-1 was necessary here in the path.
                 #   Maybe there was an issue with the actual loading of the jsonl-files
-                c = byte_char.decode("utf8")
+                c = byte_char.decode(DEFAULT_ENCODING)
             except Exception as exception:
                 c = ""
                 warnings.warn(f'Encountered invalid char: "{byte_char}".')

--- a/src/modalities/dataloader/large_file_lines_reader.py
+++ b/src/modalities/dataloader/large_file_lines_reader.py
@@ -1,10 +1,7 @@
 import pickle
-import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List
-
-import numpy as np
 
 from modalities.constants import DEFAULT_ENCODING
 
@@ -58,21 +55,6 @@ class LargeFileLinesReader(BaseReader):
         return self.__read_from_raw_file(offset, sample_length_in_bytes)
 
     def __read_from_raw_file(self, offset: int, sample_length_in_bytes: int) -> str:
-        def safe_decoder(byte_char):
-            try:
-                # TODO: verify why iso-8859-1 was necessary here in the path.
-                #   Maybe there was an issue with the actual loading of the jsonl-files
-                c = byte_char.decode(DEFAULT_ENCODING)
-            except Exception as exception:
-                c = ""
-                warnings.warn(f'Encountered invalid char: "{byte_char}".')
-                warnings.warn(f"Encountered problem: {exception}")
-            return c
-
-        string = (
-            np.memmap(self.raw_data_path, mode="r", offset=offset, shape=(sample_length_in_bytes,)).view("S1").tolist()
-        )
-        decoded_string = []
-        for c in string:
-            decoded_string.append(safe_decoder(c))
-        return "".join(decoded_string)
+        f = self.raw_data_path.open(encoding=DEFAULT_ENCODING)
+        f.seek(offset)
+        return f.read(sample_length_in_bytes)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,10 +30,11 @@ _ROOT_DIR = Path(__file__).parents[1]
 def dummy_packed_data_path(tmpdir) -> Path:
     data = b""
     header_size_in_bytes = 8
-    int_size_in_bytes = 4
+    token_size_in_bytes = 4
     tokens = list(range(20))
-    data += (len(tokens) * int_size_in_bytes).to_bytes(header_size_in_bytes, byteorder="big")
-    data += b"".join([t.to_bytes(int_size_in_bytes, byteorder="big") for t in tokens])
+    data += (len(tokens) * token_size_in_bytes).to_bytes(header_size_in_bytes, byteorder="big")
+    data += token_size_in_bytes.to_bytes(4, byteorder="big")
+    data += b"".join([t.to_bytes(token_size_in_bytes, byteorder="big") for t in tokens])
     index = [(4, 24), (28, 40), (68, 12), (80, 4)]  # [(index,len), ...] -> in 4 bytes #lengths: 6,10,3,1
     data += pickle.dumps(index)
     dummy_packed_data_path = Path(tmpdir, "dummy.pbin")

--- a/tests/dataloader/test_packed_dataset.py
+++ b/tests/dataloader/test_packed_dataset.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 
 from modalities.dataloader.create_packed_data import PackedDataGenerator
@@ -50,8 +51,10 @@ def test_create_packed_dataset(indexed_dummy_data_path, gpt2_tokenizer):
     start_of_jsonl_content = "0 Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor"
     tokenized_start_of_jsonl_content = gpt2_tokenizer(start_of_jsonl_content)["input_ids"]
     packed_dataset_iterator = iter(packed_dataset)
-    assert tokenized_start_of_jsonl_content[:block_size] == next(packed_dataset_iterator)["input_ids"]
-    assert tokenized_start_of_jsonl_content[block_size : 2 * block_size] == next(packed_dataset_iterator)["input_ids"]
+    np.testing.assert_equal(tokenized_start_of_jsonl_content[:block_size], next(packed_dataset_iterator)["input_ids"])
+    np.testing.assert_equal(
+        tokenized_start_of_jsonl_content[block_size : 2 * block_size], next(packed_dataset_iterator)["input_ids"]
+    )
     assert len(packed_dataset.index_base) == 12
 
     # check validity of index section in packed dataset

--- a/tests/dataloader/test_packed_dataset.py
+++ b/tests/dataloader/test_packed_dataset.py
@@ -35,11 +35,10 @@ def test_packed_continuous_dataset_missing_file(dummy_packed_data_path):
         PackedMemMapDatasetContinuous(dummy_packed_data_path, block_size=10, sample_key="input_ids")
 
 
-@pytest.mark.parametrize("max_num_of_tokens, expected_index_size", [(None, 12), (10, 1)])
-def test_create_packed_dataset(indexed_dummy_data_path, gpt2_tokenizer, max_num_of_tokens, expected_index_size):
+def test_create_packed_dataset(indexed_dummy_data_path, gpt2_tokenizer):
     block_size = 5
     packed_generator = PackedDataGenerator(
-        src_path=indexed_dummy_data_path.raw_data_path, tokenizer=gpt2_tokenizer, max_number_of_tokens=max_num_of_tokens
+        src_path=indexed_dummy_data_path.raw_data_path, tokenizer=gpt2_tokenizer, number_of_processes=2
     )
     default_packed_dataset_path = packed_generator._default_destination_path()
     assert not default_packed_dataset_path.is_file()
@@ -53,7 +52,7 @@ def test_create_packed_dataset(indexed_dummy_data_path, gpt2_tokenizer, max_num_
     packed_dataset_iterator = iter(packed_dataset)
     assert tokenized_start_of_jsonl_content[:block_size] == next(packed_dataset_iterator)["input_ids"]
     assert tokenized_start_of_jsonl_content[block_size : 2 * block_size] == next(packed_dataset_iterator)["input_ids"]
-    assert len(packed_dataset.index_base) == expected_index_size
+    assert len(packed_dataset.index_base) == 12
 
     # check validity of index section in packed dataset
     for idx, (offset, entry_length) in enumerate(packed_dataset.index_base[:-1]):


### PR DESCRIPTION
When playing around with the Dataset implementations of `PackedMemMapDataset` using OpenGPT-X data, decoding errors happened. This was also discovered in the past, that this data cannot get properly decoded using "utf8".
Although this very likely to be problem with the conversion of the respective data and the resulting encoding there, a potential solution is provided within this PR.

> **Note**: This branch is based on https://github.com/Modalities/modalities/pull/9 in order to use the respective test infrastructure and should get therefore merged afterwards, but not beforehand.