### PR TITLE
fix: #97 Unused attributes in a component's config yaml are just ignored by Pydantic

### DIFF
--- a/config_files/training/config_lorem_ipsum.yaml
+++ b/config_files/training/config_lorem_ipsum.yaml
@@ -261,7 +261,6 @@ batch_progress_subscriber:
   variant_key: rich
   config:
     local_rank: ${settings.cuda_env.local_rank}
-    world_size: ${settings.cuda_env.world_size}
     global_num_seen_steps: ${settings.training.global_num_seen_steps}
     train_dataloader:
       instance_key: train_dataloader

--- a/tests/config/test_component_factory.py
+++ b/tests/config/test_component_factory.py
@@ -109,3 +109,70 @@ def test_single_component(config_file_path: Path, component_factory: ComponentFa
 
     components = component_factory._build_config(config_dict=config_dict, component_names=component_names)
     assert "custom_comp_1" in components
+import pytest
+from pydantic import BaseModel
+from modalities.config.component_factory import ComponentFactory
+
+class TestComponentFactory:
+    @pytest.fixture
+    def component_factory(self):
+        # Create a ComponentFactory instance with a dummy registry
+        return ComponentFactory(registry=None)
+
+    def test_assert_valid_config_keys_with_valid_keys(self, component_factory):
+        # Define a dummy component config type
+        class DummyConfig(BaseModel):
+            required_key: str
+            optional_key: str = "default"
+
+        # Create a valid config dictionary
+        config_dict = {
+            "required_key": "value",
+            "optional_key": "value",
+        }
+
+        # Call the _assert_valid_config_keys method
+        component_factory._assert_valid_config_keys(
+            component_key="dummy",
+            variant_key="default",
+            config_dict=config_dict,
+            component_config_type=DummyConfig,
+        )
+
+        # No exception should be raised
+
+    def test_assert_valid_config_keys_with_invalid_keys(self, component_factory):
+        # Define a dummy component config type
+        class DummyConfig(BaseModel):
+            required_key: str
+            optional_key: str = "default"
+
+        # Create an invalid config dictionary with an extra key
+        config_dict = {
+            "required_key": "value",
+            "optional_key": "value",
+            "extra_key": "value",
+        }
+
+        # Call the _assert_valid_config_keys method and expect a ValueError
+        with pytest.raises(ValueError):
+            component_factory._assert_valid_config_keys(
+                component_key="dummy",
+                variant_key="default",
+                config_dict=config_dict,
+                component_config_type=DummyConfig,
+            )
+
+        # Create a valid config dictionary
+        valid_config_dict = {
+            "required_key": "value",
+            "optional_key": "value",
+        }
+
+        # Call the _assert_valid_config_keys method and expect no exception
+        component_factory._assert_valid_config_keys(
+            component_key="dummy",
+            variant_key="default",
+            config_dict=valid_config_dict,
+            component_config_type=DummyConfig,
+        )


### PR DESCRIPTION
Implemented verification that all required attributes are set and not more than optional + required attributes are present.
The does not use Pydantics verification methods, but implements the check in native python. This allows for a very clear error message about the configuration. 

With this fix, the misconfigured config
```yaml
batch_progress_subscriber:
  component_key: progress_subscriber
  variant_key: rich
```
was fixed.
