### PR TITLE
Fix Pre-LN for GPT2 Model

### DIFF
--- a/src/modalities/models/gpt2/gpt2_model.py
+++ b/src/modalities/models/gpt2/gpt2_model.py
@@ -330,10 +330,8 @@ class GPT2Block(nn.Module):
             raise NotImplementedError("unimplemented activation")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.attention_norm(x)
-        x = x + self.attn(x)
-        x = self.ffn_norm(x)
-        x = x + self.mlp(x)
+        x = x + self.attn(self.attention_norm(x))
+        x = x + self.mlp(self.ffn_norm(x))
         return x
 
 


### PR DESCRIPTION
This PR fixes the pre-LN by reverting the changes (accidentally?) introduced [here]( https://github.com/Modalities/modalities/commit/8dd74a4f98968be85c1600200cb6fd0aa5700553#diff-7b510b8da861fb91767d9aefe8db60e8ee5ae624aec986b7dc36da5f34ed48adL207)

References:
- Fig.1 & Tab. 1 in the paper [On Layer Normalization in the Transformer Architecture](https://arxiv.org/abs/2002.04745)
- [nanoGPT](https://github.com/karpathy/nanoGPT/blob/master/model.py#L103) 