### PR TITLE
Implementation of multiple attention mechanisms

### DIFF
--- a/config_files/training/config_lorem_ipsum.yaml
+++ b/config_files/training/config_lorem_ipsum.yaml
@@ -194,6 +194,7 @@ model:
             n_embd: ${model.config.n_embd}
             n_head: ${model.config.n_head_q} #it has to be head_q here
             seq_length_dim: -2
+    attention_implementation: manual
     activation_type: gelu
     weight_init:
       mean: 0.0

--- a/src/modalities/models/gpt2/gpt2_model.py
+++ b/src/modalities/models/gpt2/gpt2_model.py
@@ -190,7 +190,6 @@ class CausalSelfAttention(nn.Module):
         attention_impl: AttentionImplementation,
         bias: bool,
         dropout: float,
-        block_size: int,
     ):
         super().__init__()
         assert n_embd % n_head_q == 0, "`n_embd needs` to be divisible by `n_head_q`."
@@ -372,7 +371,6 @@ class GPT2Block(nn.Module):
         attention_impl: AttentionImplementation,
         attention_config: AttentionConfig,
         dropout: float,
-        block_size: int,
         ffn_hidden: int,
         attention_norm: nn.Module,
         ffn_norm: nn.Module,
@@ -388,7 +386,6 @@ class GPT2Block(nn.Module):
             attention_impl=attention_impl,
             bias=bias,
             dropout=dropout,
-            block_size=block_size,
         )
         if activation_type == ActivationType.GELU:
             self.mlp = TransformerMLP(n_embd=n_embd, ffn_hidden=ffn_hidden, bias=bias, dropout=dropout)
@@ -469,7 +466,6 @@ class GPT2LLM(NNModel):
                             attention_impl=attention_implementation,
                             attention_config=attention_config,
                             dropout=dropout,
-                            block_size=block_size,
                             ffn_hidden=ffn_hidden,
                             attention_norm=deepcopy(attention_norm),
                             ffn_norm=deepcopy(ffn_norm),

--- a/src/modalities/models/gpt2/gpt2_model.py
+++ b/src/modalities/models/gpt2/gpt2_model.py
@@ -180,6 +180,29 @@ class GPT2LLMConfig(BaseModel):
         return self
 
 
+def _repeat_kv(x: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    Source code adopted from
+    https://github.com/facebookresearch/llama/blob/9a001c7a0987afd7b8de94e538916eff8950a73a/llama/model.py#L164
+    Adapted ordered dimensions and namings: bs=B, n_kv_heads=nh_kv, slen=T, head_dim=hs
+    """
+    B, nh_kv, T, hs = x.shape
+    if n_rep == 1:
+        return x
+    return x[:, :, None, :, :].expand(B, nh_kv, n_rep, T, hs).reshape(B, nh_kv * n_rep, T, hs)
+
+
+def repeat_kv_heads(q, k, v):
+    # repeat k/v heads if self.n_rep > 1
+    n_head_q = q.shape[1]
+    n_head_kv = k.shape[1]
+    if n_head_q != n_head_kv:
+        n_rep = n_head_q // n_head_kv
+        k = _repeat_kv(k, n_rep)  # (B, nh_q, T, hs)
+        v = _repeat_kv(v, n_rep)  # (B, nh_q, T, hs)
+    return k, v
+
+
 class CausalSelfAttention(nn.Module):
     def __init__(
         self,
@@ -195,10 +218,6 @@ class CausalSelfAttention(nn.Module):
         super().__init__()
         assert n_embd % n_head_q == 0, "`n_embd needs` to be divisible by `n_head_q`."
         assert n_head_q % n_head_kv == 0, "`n_head_q needs` to be divisible by `n_head_kv`."
-        if attention_impl in ["manual", "pytorch_flash"]:
-            assert (
-                n_head_q == n_head_kv
-            ), "manual/pytorch_flash attention don't support group query attn & require `n_head_q` == `n_head_kv`"
 
         self.n_rep = n_head_q // n_head_kv
         self.attention_impl = attention_impl
@@ -273,6 +292,7 @@ class CausalSelfAttention(nn.Module):
         attention_impl: AttentionImplementation,
     ) -> torch.Tensor:
         if attention_impl == AttentionImplementation.MANUAL:
+            k, v = repeat_kv_heads(q, k, v)  # for GQA (group query attention)
             y = manual_scaled_dot_product_attention(
                 query=q,
                 key=k,
@@ -283,6 +303,7 @@ class CausalSelfAttention(nn.Module):
             )  # (B, nh_q, T, hd)
             y = y.transpose(1, 2).contiguous()  # (B, T, nh_q, hd)
         elif attention_impl == AttentionImplementation.PYTORCH_FLASH:
+            k, v = repeat_kv_heads(q, k, v)  # for GQA (group query attention)
             y = torch.nn.functional.scaled_dot_product_attention(
                 query=q,
                 key=k,

--- a/src/modalities/models/gpt2/gpt2_model.py
+++ b/src/modalities/models/gpt2/gpt2_model.py
@@ -265,7 +265,7 @@ class CausalSelfAttention(nn.Module):
         return q, k, v
 
     @staticmethod
-    def execute_flash_attention(
+    def execute_attention(
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
@@ -310,7 +310,7 @@ class CausalSelfAttention(nn.Module):
 
         # q: (B, nh_q, T, hd), k: (B, nh_kv, T, hd), v: (B, nh_kv, T, hd)
         q, k, v = CausalSelfAttention.execute_qkv_transforms(q, k, v, self.qkv_transforms, self.n_head_q)
-        y = CausalSelfAttention.execute_flash_attention(q, k, v, self.dropout, self.attention_impl)  # (B, T, nh_q, hd)
+        y = CausalSelfAttention.execute_attention(q, k, v, self.dropout, self.attention_impl)  # (B, T, nh_q, hd)
         y = y.reshape(B, T, self.n_embd)  # (B, T, n_embd), re-assemble all head outputs side by side
         return self.resid_dropout(self.c_proj(y))  # (B, T, n_embd), output projection
 

--- a/tests/models/test_causal_self_attention.py
+++ b/tests/models/test_causal_self_attention.py
@@ -1,12 +1,20 @@
+"""
+Note: test_attention_types_approximate_equality can print the output of different attention implementations. 
+      To do so, turn on verbose and run 'python tests/models/test_causal_self_attention.py -s'
+"""
+from copy import deepcopy
+
 import pytest
 import torch
 
 from modalities.models.gpt2.gpt2_model import AttentionConfig, CausalSelfAttention
 
+torch.manual_seed(0)
+
 
 def _get_random_input_seq(embedding_shape):
     flash_attn_supported_dtype = torch.bfloat16
-    return torch.rand(size=embedding_shape, dtype=flash_attn_supported_dtype)
+    return torch.rand(size=embedding_shape, dtype=flash_attn_supported_dtype).cuda()
 
 
 def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, block_size, attention_impl, attention_config):
@@ -31,21 +39,21 @@ def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, block_size, attenti
 @pytest.mark.parametrize(
     "n_head_q, n_head_kv, n_embd, attention_impl, successful",
     [
+        # manual
+        (4, 4, 32, "manual", True),
+        (8, 2, 32, "manual", False),  # group query attention not implemented for manual attention
+        (9, 8, 32, "manual", False),
+        (8, 3, 32, "manual", False),
+        # pytorch_flash
+        (4, 4, 32, "pytorch_flash", True),
+        (8, 2, 32, "pytorch_flash", False),  # group query attention not implemented for pytorch_flash attention
+        (9, 8, 32, "pytorch_flash", False),
+        (8, 3, 32, "pytorch_flash", False),
         # dao_flash
         (4, 4, 32, "dao_flash", True),
         (8, 2, 32, "dao_flash", True),
         (9, 8, 32, "dao_flash", False),
         (8, 3, 32, "dao_flash", False),
-        # pytorch_flash
-        (4, 4, 32, "pytorch_flash", True),
-        (8, 2, 32, "pytorch_flash", False),
-        (9, 8, 32, "pytorch_flash", False),
-        (8, 3, 32, "pytorch_flash", False),
-        # manual
-        (4, 4, 32, "manual", True),
-        (8, 2, 32, "manual", False),
-        (9, 8, 32, "manual", False),
-        (8, 3, 32, "manual", False),
     ],
 )
 def test_forward_pass_success(n_head_q, n_head_kv, n_embd, attention_impl, successful):
@@ -76,39 +84,96 @@ def test_forward_pass_success(n_head_q, n_head_kv, n_embd, attention_impl, succe
 @pytest.mark.parametrize(
     "seq_length, n_head_q, n_head_kv, head_dim, attention_impl",
     [
-        # dao_flash
-        (12, 4, 4, 32, "dao_flash"),
-        (12, 8, 2, 32, "dao_flash"),
-        (16, 8, 8, 16, "dao_flash"),
-        # pytorch_flash
-        (12, 4, 4, 32, "pytorch_flash"),
-        (16, 8, 8, 16, "pytorch_flash"),
         # manual
         (12, 4, 4, 32, "manual"),
         (16, 8, 8, 16, "manual"),
+        # pytorch_flash
+        (12, 4, 4, 32, "pytorch_flash"),
+        (16, 8, 8, 16, "pytorch_flash"),
+        # dao_flash
+        (12, 4, 4, 32, "dao_flash"),
+        (12, 8, 2, 32, "dao_flash"),  # group query attention
+        (16, 8, 8, 16, "dao_flash"),
     ],
 )
 def test_forward_pass_shapes(seq_length, n_head_q, n_head_kv, head_dim, attention_impl):
     # Source: https://medium.com/@maxshapp/grouped-query-attention-gqa-explained-with-code-e56ee2a1df5a
+    batch_size = 2
 
     # shapes: (batch_size, num_heads, seq_length, head_dim)
-    query_orig = torch.rand(2, n_head_q, seq_length, head_dim, dtype=torch.bfloat16).cuda()
-    key_orig = torch.rand(2, n_head_kv, seq_length, head_dim, dtype=torch.bfloat16).cuda()
-    value_orig = torch.rand(2, n_head_kv, seq_length, head_dim, dtype=torch.bfloat16).cuda()
+    query_orig = torch.rand(batch_size, n_head_q, seq_length, head_dim, dtype=torch.bfloat16).cuda()
+    key_orig = torch.rand(batch_size, n_head_kv, seq_length, head_dim, dtype=torch.bfloat16).cuda()
+    value_orig = torch.rand(batch_size, n_head_kv, seq_length, head_dim, dtype=torch.bfloat16).cuda()
 
-    attn_mask = (
-        torch.tril(torch.ones(seq_length, seq_length)).view(1, 1, seq_length, seq_length).to("cuda")
-        if attention_impl == "manual"
-        else None
-    )
     out_flash = CausalSelfAttention.execute_flash_attention(
         query_orig,
         key_orig,
         value_orig,
         dropout=0.0,
         attention_impl=attention_impl,
-        attn_mask=attn_mask,
     )
 
     # shape: (batch_size, seq_length, num_heads, head_dim)
-    assert out_flash.shape == (2, seq_length, n_head_q, head_dim)
+    assert out_flash.shape == (batch_size, seq_length, n_head_q, head_dim)
+
+
+@pytest.mark.parametrize(
+    "n_head_q, n_head_kv, n_embd, attention_impl_1, attention_impl_2, verbose",
+    [
+        # note that no group query attention is used (i.e. n_head_q == n_head_kv)
+        # manual vs. pytorch_flash
+        (4, 4, 4, "manual", "pytorch_flash", False),
+        (4, 4, 32, "manual", "pytorch_flash", False),
+        (4, 4, 768, "manual", "pytorch_flash", False),
+        (8, 8, 2048, "manual", "pytorch_flash", False),
+        # manual vs. dao_flash
+        (4, 4, 4, "manual", "dao_flash", False),
+        (4, 4, 32, "manual", "dao_flash", False),
+        (4, 4, 768, "manual", "dao_flash", False),
+        (8, 8, 2048, "manual", "dao_flash", False),
+        # pytorch_flash vs. dao_flash
+        (4, 4, 4, "pytorch_flash", "dao_flash", True),
+        (4, 4, 32, "pytorch_flash", "dao_flash", False),
+        (4, 4, 768, "pytorch_flash", "dao_flash", False),
+        (8, 8, 2048, "pytorch_flash", "dao_flash", False),
+    ],
+)
+def test_attention_implementation_approximate_equality(
+    n_head_q, n_head_kv, n_embd, attention_impl_1, attention_impl_2, verbose
+):
+    # flash attention is non-deterministic,
+    # see https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html
+    # and https://pytorch.org/docs/stable/notes/randomness.html#avoiding-nondeterministic-algorithms
+    # as well as https://github.com/pytorch/pytorch/issues/119188#issuecomment-2043157422
+
+    batch_size = 2
+    block_size = 10
+    embedding_shape = (batch_size, block_size - 1, n_embd)
+    embedded_input_seq = _get_random_input_seq(embedding_shape)
+
+    attention_config = AttentionConfig(qkv_transforms=[])
+    attention_layer_args = {
+        "n_head_q": n_head_q,
+        "n_head_kv": n_head_kv,
+        "n_embd": n_embd,
+        "block_size": block_size,
+        "attention_config": attention_config,
+        "attention_impl": attention_impl_1,
+    }
+
+    attention_layer = {}
+    attention_layer[attention_impl_1] = _get_random_attention_layer(**attention_layer_args)
+    attention_layer[attention_impl_2] = deepcopy(attention_layer[attention_impl_1])
+    attention_layer[attention_impl_2].attention_impl = attention_impl_2
+
+    output_tensor = {}
+    output_tensor[attention_impl_1] = attention_layer[attention_impl_1](embedded_input_seq)
+    output_tensor[attention_impl_2] = attention_layer[attention_impl_2](embedded_input_seq)
+    if verbose:
+        print(f"{attention_impl_1} vs. {attention_impl_2}: \n{output_tensor}")
+    torch.testing.assert_close(
+        output_tensor[attention_impl_1],
+        output_tensor[attention_impl_2],
+        atol=2e-3,  # default for bfloat16: 1e-5
+        rtol=0.016,  # default for bfloat16: 0.016
+    )

--- a/tests/models/test_causal_self_attention.py
+++ b/tests/models/test_causal_self_attention.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import pytest
 import torch
 
-from modalities.models.gpt2.gpt2_model import AttentionConfig, CausalSelfAttention
+from modalities.models.gpt2.gpt2_model import AttentionConfig, CausalSelfAttention, repeat_kv_heads
 
 torch.manual_seed(0)
 
@@ -35,23 +35,62 @@ def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, block_size, attenti
     return self_attention_layer
 
 
+@pytest.mark.parametrize(
+    "n_head_q, n_head_kv, n_embd",
+    [
+        (4, 4, 32),  # MHA (multi head attention)
+        (32, 32, 768),  # MHA (multi head attention)
+        (4, 2, 32),  # GQA (group query attention)
+        (6, 2, 32),  # GQA
+        (32, 4, 768),  # GQA
+    ],
+)
+def test_repeat_kv_heads(n_head_q, n_head_kv, n_embd):
+    batch_size = 2
+    block_size = 10
+    head_dim = n_embd // n_head_q
+    AttentionConfig(qkv_transforms=[])
+
+    q = torch.rand(batch_size, n_head_q, block_size - 1, head_dim, dtype=torch.bfloat16).cuda()
+    k_in = torch.rand(batch_size, n_head_kv, block_size - 1, head_dim, dtype=torch.bfloat16).cuda()
+    v_in = torch.rand(batch_size, n_head_kv, block_size - 1, head_dim, dtype=torch.bfloat16).cuda()
+
+    k_out, v_out = repeat_kv_heads(q, k_in, v_in)
+
+    # assert that shapes are correct: (batch_size, num_heads, seq_length, head_dim)
+    assert k_out.shape == q.shape
+    assert v_out.shape == q.shape
+
+    # assert that repetitions are correct
+    if n_head_q != n_head_kv:
+        # e.g. n_head_q = 6, n_head_kv = 2
+        for i in range(0, n_head_q, n_head_q // n_head_kv):  # e.g. i = 0,3
+            for j in range(1, n_head_q // n_head_kv):  # e.g. j = 1,2
+                torch.testing.assert_close(
+                    k_out[:, i, :, :], k_out[:, i + j, :, :]
+                )  # compares i=0 vs. i+j=1,2 | i=3 vs. i+j=4,5
+                torch.testing.assert_close(
+                    v_out[:, i, :, :], v_out[:, i + j, :, :]
+                )  # compares i=0 vs. i+j=1,2 | i=3 vs. i+j=4,5
+
+
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="This e2e test requires 1 GPU.")
 @pytest.mark.parametrize(
     "n_head_q, n_head_kv, n_embd, attention_impl, successful",
     [
         # manual
-        (4, 4, 32, "manual", True),
-        (8, 2, 32, "manual", False),  # group query attention not implemented for manual attention
+        (4, 4, 32, "manual", True),  # MHA
+        (8, 2, 32, "manual", True),  # GQA
         (9, 8, 32, "manual", False),
         (8, 3, 32, "manual", False),
         # pytorch_flash
-        (4, 4, 32, "pytorch_flash", True),
-        (8, 2, 32, "pytorch_flash", False),  # group query attention not implemented for pytorch_flash attention
+        (4, 4, 32, "pytorch_flash", True),  # MHA
+        (8, 2, 32, "pytorch_flash", True),  # GQA
         (9, 8, 32, "pytorch_flash", False),
         (8, 3, 32, "pytorch_flash", False),
         # dao_flash
-        (4, 4, 32, "dao_flash", True),
-        (8, 2, 32, "dao_flash", True),
+        (4, 4, 32, "dao_flash", True),  # MHA
+        (8, 2, 32, "dao_flash", True),  # GQA
         (9, 8, 32, "dao_flash", False),
         (8, 3, 32, "dao_flash", False),
     ],
@@ -85,15 +124,17 @@ def test_forward_pass_success(n_head_q, n_head_kv, n_embd, attention_impl, succe
     "seq_length, n_head_q, n_head_kv, head_dim, attention_impl",
     [
         # manual
-        (12, 4, 4, 32, "manual"),
-        (16, 8, 8, 16, "manual"),
+        (12, 4, 4, 32, "manual"),  # MHA
+        (12, 8, 2, 32, "manual"),  # GQA
+        (16, 8, 8, 16, "manual"),  # MHA
         # pytorch_flash
-        (12, 4, 4, 32, "pytorch_flash"),
-        (16, 8, 8, 16, "pytorch_flash"),
+        (12, 4, 4, 32, "pytorch_flash"),  # MHA
+        (12, 8, 2, 32, "pytorch_flash"),  # GQA
+        (16, 8, 8, 16, "pytorch_flash"),  # MHA
         # dao_flash
-        (12, 4, 4, 32, "dao_flash"),
-        (12, 8, 2, 32, "dao_flash"),  # group query attention
-        (16, 8, 8, 16, "dao_flash"),
+        (12, 4, 4, 32, "dao_flash"),  # MHA
+        (12, 8, 2, 32, "dao_flash"),  # GQA
+        (16, 8, 8, 16, "dao_flash"),  # MHA
     ],
 )
 def test_forward_pass_shapes(seq_length, n_head_q, n_head_kv, head_dim, attention_impl):
@@ -120,22 +161,24 @@ def test_forward_pass_shapes(seq_length, n_head_q, n_head_kv, head_dim, attentio
 @pytest.mark.parametrize(
     "n_head_q, n_head_kv, n_embd, attention_impl_1, attention_impl_2, verbose",
     [
-        # note that no group query attention is used (i.e. n_head_q == n_head_kv)
         # manual vs. pytorch_flash
-        (4, 4, 4, "manual", "pytorch_flash", True),
+        (4, 4, 4, "manual", "pytorch_flash", False),  # MHA
         (4, 4, 32, "manual", "pytorch_flash", False),
         (4, 4, 768, "manual", "pytorch_flash", False),
         (8, 8, 2048, "manual", "pytorch_flash", False),
+        (8, 2, 2048, "manual", "pytorch_flash", False),  # GQA
         # manual vs. dao_flash
-        (4, 4, 4, "manual", "dao_flash", False),
+        (4, 4, 4, "manual", "dao_flash", False),  # MQA
         (4, 4, 32, "manual", "dao_flash", False),
         (4, 4, 768, "manual", "dao_flash", False),
         (8, 8, 2048, "manual", "dao_flash", False),
+        (8, 2, 2048, "manual", "dao_flash", False),  # GQA
         # pytorch_flash vs. dao_flash
         (4, 4, 4, "pytorch_flash", "dao_flash", False),
         (4, 4, 32, "pytorch_flash", "dao_flash", False),
         (4, 4, 768, "pytorch_flash", "dao_flash", False),
         (8, 8, 2048, "pytorch_flash", "dao_flash", False),
+        (8, 2, 2048, "pytorch_flash", "dao_flash", False),  # GQA
     ],
 )
 def test_attention_implementation_approximate_equality(
@@ -174,6 +217,6 @@ def test_attention_implementation_approximate_equality(
     torch.testing.assert_close(
         output_tensor[attention_impl_1],
         output_tensor[attention_impl_2],
-        atol=2e-3,  # default for bfloat16: 1e-5
+        atol=2.5e-3,  # default for bfloat16: 1e-5
         rtol=0.016,  # default for bfloat16: 0.016
     )

--- a/tests/models/test_causal_self_attention.py
+++ b/tests/models/test_causal_self_attention.py
@@ -9,7 +9,7 @@ def _get_random_input_seq(embedding_shape):
     return torch.rand(size=embedding_shape, dtype=flash_attn_supported_dtype)
 
 
-def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, block_size, attention_config):
+def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, block_size, attention_impl, attention_config):
     self_attention_layer = CausalSelfAttention(
         n_head_q=n_head_q,
         n_head_kv=n_head_kv,
@@ -18,6 +18,7 @@ def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, block_size, attenti
         dropout=0.0,
         block_size=block_size,
         attention_config=attention_config,
+        attention_impl=attention_impl,
     ).cuda()
     self_attention_layer.q_attn = self_attention_layer.q_attn.bfloat16()
     self_attention_layer.k_attn = self_attention_layer.k_attn.bfloat16()
@@ -28,18 +29,29 @@ def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, block_size, attenti
 
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="This e2e test requires 1 GPU.")
 @pytest.mark.parametrize(
-    "n_head_q, n_head_kv, n_embd, successful",
+    "n_head_q, n_head_kv, n_embd, attention_impl, successful",
     [
-        (4, 4, 32, True),
-        (8, 2, 32, True),
-        (9, 8, 32, False),
-        (8, 3, 32, False),
+        # dao_flash
+        (4, 4, 32, "dao_flash", True),
+        (8, 2, 32, "dao_flash", True),
+        (9, 8, 32, "dao_flash", False),
+        (8, 3, 32, "dao_flash", False),
+        # pytorch_flash
+        (4, 4, 32, "pytorch_flash", True),
+        (8, 2, 32, "pytorch_flash", False),
+        (9, 8, 32, "pytorch_flash", False),
+        (8, 3, 32, "pytorch_flash", False),
+        # manual
+        (4, 4, 32, "manual", True),
+        (8, 2, 32, "manual", False),
+        (9, 8, 32, "manual", False),
+        (8, 3, 32, "manual", False),
     ],
 )
-def test_forward_pass_success(n_head_q, n_head_kv, n_embd, successful):
+def test_forward_pass_success(n_head_q, n_head_kv, n_embd, attention_impl, successful):
     batch_size = 2
     block_size = 10
-    embedding_shape = (batch_size, block_size, n_embd)
+    embedding_shape = (batch_size, block_size - 1, n_embd)
     attention_config = AttentionConfig(qkv_transforms=[])
     attention_layer_args = {
         "n_head_q": n_head_q,
@@ -47,6 +59,7 @@ def test_forward_pass_success(n_head_q, n_head_kv, n_embd, successful):
         "n_embd": n_embd,
         "block_size": block_size,
         "attention_config": attention_config,
+        "attention_impl": attention_impl,
     }
 
     if not successful:
@@ -60,14 +73,42 @@ def test_forward_pass_success(n_head_q, n_head_kv, n_embd, successful):
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="This e2e test requires 1 GPU.")
-def test_forward_equality():
+@pytest.mark.parametrize(
+    "seq_length, n_head_q, n_head_kv, head_dim, attention_impl",
+    [
+        # dao_flash
+        (12, 4, 4, 32, "dao_flash"),
+        (12, 8, 2, 32, "dao_flash"),
+        (16, 8, 8, 16, "dao_flash"),
+        # pytorch_flash
+        (12, 4, 4, 32, "pytorch_flash"),
+        (16, 8, 8, 16, "pytorch_flash"),
+        # manual
+        (12, 4, 4, 32, "manual"),
+        (16, 8, 8, 16, "manual"),
+    ],
+)
+def test_forward_pass_shapes(seq_length, n_head_q, n_head_kv, head_dim, attention_impl):
     # Source: https://medium.com/@maxshapp/grouped-query-attention-gqa-explained-with-code-e56ee2a1df5a
 
-    # shapes: (batch_size, seq_len, num_heads, head_dim)
-    query_orig = torch.rand(1, 8, 12, 16, dtype=torch.bfloat16).cuda()
-    key_orig = torch.rand(1, 2, 12, 16, dtype=torch.bfloat16).cuda()
-    value_orig = torch.rand(1, 2, 12, 16, dtype=torch.bfloat16).cuda()
+    # shapes: (batch_size, num_heads, seq_length, head_dim)
+    query_orig = torch.rand(2, n_head_q, seq_length, head_dim, dtype=torch.bfloat16).cuda()
+    key_orig = torch.rand(2, n_head_kv, seq_length, head_dim, dtype=torch.bfloat16).cuda()
+    value_orig = torch.rand(2, n_head_kv, seq_length, head_dim, dtype=torch.bfloat16).cuda()
 
-    out_flash = CausalSelfAttention.execute_flash_attention(query_orig, key_orig, value_orig, dropout=0.0)
+    attn_mask = (
+        torch.tril(torch.ones(seq_length, seq_length)).view(1, 1, seq_length, seq_length).to("cuda")
+        if attention_impl == "manual"
+        else None
+    )
+    out_flash = CausalSelfAttention.execute_flash_attention(
+        query_orig,
+        key_orig,
+        value_orig,
+        dropout=0.0,
+        attention_impl=attention_impl,
+        attn_mask=attn_mask,
+    )
 
-    assert out_flash.shape == (1, 12, 8, 16)
+    # shape: (batch_size, seq_length, num_heads, head_dim)
+    assert out_flash.shape == (2, seq_length, n_head_q, head_dim)

--- a/tests/models/test_causal_self_attention.py
+++ b/tests/models/test_causal_self_attention.py
@@ -17,14 +17,13 @@ def _get_random_input_seq(embedding_shape):
     return torch.rand(size=embedding_shape, dtype=flash_attn_supported_dtype).cuda()
 
 
-def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, block_size, attention_impl, attention_config):
+def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, attention_impl, attention_config):
     self_attention_layer = CausalSelfAttention(
         n_head_q=n_head_q,
         n_head_kv=n_head_kv,
         n_embd=n_embd,
         bias=False,
         dropout=0.0,
-        block_size=block_size,
         attention_config=attention_config,
         attention_impl=attention_impl,
     ).cuda()
@@ -107,7 +106,6 @@ def test_forward_pass_success(n_head_q, n_head_kv, n_embd, attention_impl, succe
         "n_head_q": n_head_q,
         "n_head_kv": n_head_kv,
         "n_embd": n_embd,
-        "block_size": block_size,
         "attention_config": attention_config,
         "attention_impl": attention_impl,
     }
@@ -202,7 +200,6 @@ def test_attention_implementation_approximate_equality(
         "n_head_q": n_head_q,
         "n_head_kv": n_head_kv,
         "n_embd": n_embd,
-        "block_size": block_size,
         "attention_config": attention_config,
         "attention_impl": attention_impl_1,
     }

--- a/tests/models/test_causal_self_attention.py
+++ b/tests/models/test_causal_self_attention.py
@@ -1,6 +1,6 @@
 """
 Note: test_attention_types_approximate_equality can print the output of different attention implementations. 
-      To do so, turn on verbose and run 'python tests/models/test_causal_self_attention.py -s'
+      To do so, turn on verbose and run 'pytest tests/models/test_causal_self_attention.py -s'
 """
 from copy import deepcopy
 
@@ -105,7 +105,7 @@ def test_forward_pass_shapes(seq_length, n_head_q, n_head_kv, head_dim, attentio
     key_orig = torch.rand(batch_size, n_head_kv, seq_length, head_dim, dtype=torch.bfloat16).cuda()
     value_orig = torch.rand(batch_size, n_head_kv, seq_length, head_dim, dtype=torch.bfloat16).cuda()
 
-    out_flash = CausalSelfAttention.execute_flash_attention(
+    out = CausalSelfAttention.execute_attention(
         query_orig,
         key_orig,
         value_orig,
@@ -114,7 +114,7 @@ def test_forward_pass_shapes(seq_length, n_head_q, n_head_kv, head_dim, attentio
     )
 
     # shape: (batch_size, seq_length, num_heads, head_dim)
-    assert out_flash.shape == (batch_size, seq_length, n_head_q, head_dim)
+    assert out.shape == (batch_size, seq_length, n_head_q, head_dim)
 
 
 @pytest.mark.parametrize(
@@ -122,7 +122,7 @@ def test_forward_pass_shapes(seq_length, n_head_q, n_head_kv, head_dim, attentio
     [
         # note that no group query attention is used (i.e. n_head_q == n_head_kv)
         # manual vs. pytorch_flash
-        (4, 4, 4, "manual", "pytorch_flash", False),
+        (4, 4, 4, "manual", "pytorch_flash", True),
         (4, 4, 32, "manual", "pytorch_flash", False),
         (4, 4, 768, "manual", "pytorch_flash", False),
         (8, 8, 2048, "manual", "pytorch_flash", False),
@@ -132,7 +132,7 @@ def test_forward_pass_shapes(seq_length, n_head_q, n_head_kv, head_dim, attentio
         (4, 4, 768, "manual", "dao_flash", False),
         (8, 8, 2048, "manual", "dao_flash", False),
         # pytorch_flash vs. dao_flash
-        (4, 4, 4, "pytorch_flash", "dao_flash", True),
+        (4, 4, 4, "pytorch_flash", "dao_flash", False),
         (4, 4, 32, "pytorch_flash", "dao_flash", False),
         (4, 4, 768, "pytorch_flash", "dao_flash", False),
         (8, 8, 2048, "pytorch_flash", "dao_flash", False),

--- a/tests/test_yaml_configs/config_lorem_ipsum.yaml
+++ b/tests/test_yaml_configs/config_lorem_ipsum.yaml
@@ -204,6 +204,7 @@ model:
             n_embd: ${model.config.n_embd}
             n_head: ${model.config.n_head_q} #it has to be head_q here
             seq_length_dim: -2
+    attention_implementation: dao_flash
     activation_type: gelu
     weight_init:
       mean: 0.0


### PR DESCRIPTION
This PR implements `manual attention` and `pytorch flash attention`, in addition to the previously implemented `dao flash attention`. Group Query Attention is supported. 