### PR TITLE
Various small fixes for Mamba, unit tests & linting

### DIFF
--- a/config_files/training/config_example_coca.yaml
+++ b/config_files/training/config_example_coca.yaml
@@ -144,9 +144,6 @@ checkpoint_saving:
         checkpoint_path: ${settings.paths.checkpointing_path}
         global_rank: ${settings.cuda_env.global_rank}
         experiment_id: ${settings.experiment_id}
-        mixed_precision_settings: FP_16
-        sharding_strategy: FULL_SHARD
-        block_names: [TransformerBlock, VisionTransformerBlock]
 
 loss_fn:
   component_key: loss
@@ -257,7 +254,6 @@ batch_progress_subscriber:
   variant_key: rich
   config:
     local_rank: ${settings.cuda_env.local_rank}
-    world_size: ${settings.cuda_env.world_size}
     global_num_seen_steps: ${settings.training.global_num_seen_steps}
     train_dataloader:
       instance_key: train_dataloader

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
     "packaging",
     "einops>=0.7.0",
     "flash-attn",     # install this directly via `pip install flash-attn --no-build-isolation`
+    "mamba-ssm",
+    "causal-conv1d>=1.2.0",
 ]
 
 [project.optional-dependencies]

--- a/src/modalities/models/coca/coca_model.py
+++ b/src/modalities/models/coca/coca_model.py
@@ -1,6 +1,6 @@
 import math
 from functools import partial
-from typing import Annotated, Dict, Tuple, List
+from typing import Annotated, Dict, Tuple
 
 import torch
 from einops import repeat
@@ -14,7 +14,6 @@ from modalities.models.gpt2.gpt2_model import ActivationType, WeightInitializati
 from modalities.models.model import NNModel
 from modalities.models.vision_transformer.vision_transformer_model import VisionTransformer, VisionTransformerConfig
 from modalities.nn.attention import AttentionConfig
-from transformers import PreTrainedTokenizer
 
 
 class TextDecoderConfig(BaseModel):

--- a/src/modalities/models/coca/multi_modal_decoder.py
+++ b/src/modalities/models/coca/multi_modal_decoder.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Dict, List
+from typing import Dict
 
 import torch
 import xformers.ops as xops
@@ -9,23 +9,22 @@ from modalities.models.gpt2.gpt2_model import ActivationType
 from modalities.models.model import NNModel
 from modalities.nn.attention import AttentionConfig, AttentionType, MultiHeadAttention
 from modalities.nn.mlp import MLP
-from transformers import PreTrainedTokenizer
 
 
 class TransformerBlock(nn.Module):
     def __init__(
-            self,
-            n_embd: int,
-            bias: bool,
-            epsilon: float,
-            activation: ActivationType,
-            n_head: int,
-            dropout: float,
-            ffn_hidden: int,
-            with_context: bool,
-            attention_type: AttentionType,
-            attention_config: AttentionConfig = None,
-            add_extra_mlp: bool = False,
+        self,
+        n_embd: int,
+        bias: bool,
+        epsilon: float,
+        activation: ActivationType,
+        n_head: int,
+        dropout: float,
+        ffn_hidden: int,
+        with_context: bool,
+        attention_type: AttentionType,
+        attention_config: AttentionConfig = None,
+        add_extra_mlp: bool = False,
     ):
         super().__init__()
         self.with_context = with_context
@@ -71,20 +70,20 @@ class TransformerBlock(nn.Module):
 
 class MultiModalTextDecoder(NNModel):
     def __init__(
-            self,
-            sample_key: str,
-            prediction_key: str,
-            block_size: int,
-            vocab_size: int,
-            n_layer: int,
-            n_head: int,
-            n_embd: int,
-            ffn_hidden: int,
-            dropout: float,
-            bias: bool,
-            activation: ActivationType,
-            epsilon: float,
-            attention_config: AttentionConfig,
+        self,
+        sample_key: str,
+        prediction_key: str,
+        block_size: int,
+        vocab_size: int,
+        n_layer: int,
+        n_head: int,
+        n_embd: int,
+        ffn_hidden: int,
+        dropout: float,
+        bias: bool,
+        activation: ActivationType,
+        epsilon: float,
+        attention_config: AttentionConfig,
     ):
         super().__init__()
         self.sample_key = sample_key

--- a/src/modalities/models/coca/text_decoder.py
+++ b/src/modalities/models/coca/text_decoder.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict
 
 import torch
 from torch import nn
@@ -7,25 +7,24 @@ from modalities.models.coca.multi_modal_decoder import TransformerBlock
 from modalities.models.gpt2.gpt2_model import ActivationType
 from modalities.models.model import NNModel
 from modalities.nn.attention import AttentionConfig, AttentionType
-from transformers import PreTrainedTokenizer
 
 
 class TextDecoder(NNModel):
     def __init__(
-            self,
-            sample_key: str,
-            prediction_key: str,
-            block_size: int,
-            vocab_size: int,
-            n_layer: int,
-            n_head: int,
-            n_embd: int,
-            ffn_hidden: int,
-            dropout: float,
-            bias: bool,
-            activation: ActivationType,
-            epsilon: float,
-            attention_config: AttentionConfig = None,
+        self,
+        sample_key: str,
+        prediction_key: str,
+        block_size: int,
+        vocab_size: int,
+        n_layer: int,
+        n_head: int,
+        n_embd: int,
+        ffn_hidden: int,
+        dropout: float,
+        bias: bool,
+        activation: ActivationType,
+        epsilon: float,
+        attention_config: AttentionConfig = None,
     ):
         super().__init__()
         self.sample_key = sample_key

--- a/src/modalities/models/gpt2/gpt2_model.py
+++ b/src/modalities/models/gpt2/gpt2_model.py
@@ -1,5 +1,4 @@
 import math
-import sys
 from copy import deepcopy
 from enum import Enum
 from functools import partial
@@ -10,14 +9,11 @@ import torch.nn as nn
 import xformers.ops as xops
 from flash_attn import flash_attn_func
 from pydantic import BaseModel, Field, model_validator, validator
-from torch.nn import functional as F
-from transformers import PreTrainedTokenizer
 
 from modalities.config.pydanctic_if_types import PydanticPytorchModuleType
 from modalities.config.utils import convert_base_model_config_to_dict
 from modalities.models.model import NNModel
 from modalities.util import parse_enum_by_name
-
 
 # GPT2 implementation taken from nanogpt https://github.com/karpathy/nanoGPT
 
@@ -29,20 +25,20 @@ class PositionTypes(str, Enum):
 
 class QueryKeyValueTransform(nn.Module):
     def forward(
-            self,
-            q: torch.Tensor,
-            k: torch.Tensor,
-            v: torch.Tensor,
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         pass
 
 
 class IdentityTransform(QueryKeyValueTransform):
     def forward(
-            self,
-            q: torch.Tensor,
-            k: torch.Tensor,
-            v: torch.Tensor,
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         return q, k, v
 
@@ -94,7 +90,7 @@ class RotaryTransform(QueryKeyValueTransform):
         return (x * cos) + (self.rotate_half(x) * sin)
 
     def forward(
-            self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         self._cos_cached, self._sin_cached = self._update_cos_sin_tables(k)
         q = self.apply_rotary_pos_emb(q, self._cos_cached, self._sin_cached)
@@ -169,7 +165,7 @@ class GPT2LLMConfig(BaseModel):
     @model_validator(mode="after")
     def validate_sizes(self) -> "GPT2LLMConfig":
         for param, param_name in zip(
-                [self.ffn_hidden, self.vocab_size, self.n_embd], ["ffn_hidden", "vocab_size", "n_embd"]
+            [self.ffn_hidden, self.vocab_size, self.n_embd], ["ffn_hidden", "vocab_size", "n_embd"]
         ):
             if param % 128 != 0:
                 # See https://docs.nvidia.com/deeplearning/performance/dl-performance-matrix-multiplication/index.html#requirements-tc
@@ -179,14 +175,14 @@ class GPT2LLMConfig(BaseModel):
 
 class CausalSelfAttention(nn.Module):
     def __init__(
-            self,
-            n_head_q: int,
-            n_head_kv: int,
-            n_embd: int,
-            attention_config: AttentionConfig,
-            bias: bool,
-            dropout: float,
-            block_size: int,
+        self,
+        n_head_q: int,
+        n_head_kv: int,
+        n_embd: int,
+        attention_config: AttentionConfig,
+        bias: bool,
+        dropout: float,
+        block_size: int,
     ):
         super().__init__()
         assert n_embd % n_head_q == 0, "`n_embd needs` to be divisible by `n_head_q`."
@@ -241,7 +237,7 @@ class CausalSelfAttention(nn.Module):
 
     @staticmethod
     def execute_qkv_transforms(
-            q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, qkv_transforms: nn.ModuleList, n_head_q: int
+        q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, qkv_transforms: nn.ModuleList, n_head_q: int
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         batch_size, block_size, embedding_dim = q.size()
         n_head_dim = embedding_dim // n_head_q
@@ -300,18 +296,18 @@ class TransformerMLP(nn.Module):
 
 class GPT2Block(nn.Module):
     def __init__(
-            self,
-            n_embd: int,
-            bias: bool,
-            n_head_q: int,
-            n_head_kv: int,
-            activation_type: ActivationType,
-            attention_config: AttentionConfig,
-            dropout: float,
-            block_size: int,
-            ffn_hidden: int,
-            attention_norm: nn.Module,
-            ffn_norm: nn.Module,
+        self,
+        n_embd: int,
+        bias: bool,
+        n_head_q: int,
+        n_head_kv: int,
+        activation_type: ActivationType,
+        attention_config: AttentionConfig,
+        dropout: float,
+        block_size: int,
+        ffn_hidden: int,
+        attention_norm: nn.Module,
+        ffn_norm: nn.Module,
     ):
         super().__init__()
         self.attention_norm = attention_norm
@@ -342,31 +338,28 @@ class GPT2Block(nn.Module):
 
 
 class GPT2LLM(NNModel):
-
-
     def __init__(
-            self,
-            sample_key: str,
-            prediction_key: str,
-            poe_type: PositionTypes,
-            block_size: int,
-            vocab_size: int,
-            n_layer: int,
-            n_head_q: int,
-            n_head_kv: int,
-            n_embd: int,
-            ffn_hidden: int,
-            dropout: float,
-            bias: bool,
-            activation_type: ActivationType,
-            weight_init: WeightInitializationConfig,
-            attention_config: AttentionConfig,
-            attention_norm: nn.Module,
-            ffn_norm: nn.Module,
-            lm_head_norm: nn.Module,
-            seed: int = None
+        self,
+        sample_key: str,
+        prediction_key: str,
+        poe_type: PositionTypes,
+        block_size: int,
+        vocab_size: int,
+        n_layer: int,
+        n_head_q: int,
+        n_head_kv: int,
+        n_embd: int,
+        ffn_hidden: int,
+        dropout: float,
+        bias: bool,
+        activation_type: ActivationType,
+        weight_init: WeightInitializationConfig,
+        attention_config: AttentionConfig,
+        attention_norm: nn.Module,
+        ffn_norm: nn.Module,
+        lm_head_norm: nn.Module,
+        seed: int = None,
     ):
-
         super().__init__(seed=seed)
         self.sample_key = sample_key
         self.prediction_key = prediction_key

--- a/src/modalities/models/huggingface/huggingface_models.py
+++ b/src/modalities/models/huggingface/huggingface_models.py
@@ -2,13 +2,11 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import torch
-
 from pydantic import BaseModel, ConfigDict
 from transformers import AutoModelForCausalLM, AutoModelForMaskedLM, AutoTokenizer
 
 from modalities.config.lookup_enum import LookupEnum
 from modalities.models.model import NNModel
-
 
 # Huggingface Model dependencies
 #
@@ -43,16 +41,15 @@ class HuggingFacePretrainedModelConfig(BaseModel):
 
 
 class HuggingFacePretrainedModel(NNModel):
-
     def __init__(
-            self,
-            model_type: HuggingFaceModelTypes,
-            model_name: str,
-            prediction_key: str,
-            huggingface_prediction_subscription_key: str,
-            sample_key: str,
-            model_args: Optional[Any] = None,
-            kwargs: Optional[Any] = None,
+        self,
+        model_type: HuggingFaceModelTypes,
+        model_name: str,
+        prediction_key: str,
+        huggingface_prediction_subscription_key: str,
+        sample_key: str,
+        model_args: Optional[Any] = None,
+        kwargs: Optional[Any] = None,
     ):
         super().__init__()
         if model_args is None:

--- a/src/modalities/models/mamba/ops/selective_scan_interface.py
+++ b/src/modalities/models/mamba/ops/selective_scan_interface.py
@@ -2,13 +2,12 @@
 
 import torch
 import torch.nn.functional as F
+from einops import rearrange, repeat
 from torch.cuda.amp import custom_bwd, custom_fwd
 
-from einops import rearrange, repeat
-
 try:
-    from causal_conv1d import causal_conv1d_fn
     import causal_conv1d_cuda
+    from causal_conv1d import causal_conv1d_fn
 except ImportError:
     causal_conv1d_fn = None
     causal_conv1d_cuda = None
@@ -17,10 +16,8 @@ import selective_scan_cuda
 
 
 class SelectiveScanFn(torch.autograd.Function):
-
     @staticmethod
-    def forward(ctx, u, delta, A, B, C, D=None, z=None, delta_bias=None, delta_softplus=False,
-                return_last_state=False):
+    def forward(ctx, u, delta, A, B, C, D=None, z=None, delta_bias=None, delta_softplus=False, return_last_state=False):
         if u.stride(-1) != 1:
             u = u.contiguous()
         if delta.stride(-1) != 1:
@@ -65,22 +62,41 @@ class SelectiveScanFn(torch.autograd.Function):
         # backward of selective_scan_cuda with the backward of chunk).
         # Here we just pass in None and dz will be allocated in the C++ code.
         du, ddelta, dA, dB, dC, dD, ddelta_bias, *rest = selective_scan_cuda.bwd(
-            u, delta, A, B, C, D, z, delta_bias, dout, x, out, None, ctx.delta_softplus,
-            False  # option to recompute out_z, not used here
+            u,
+            delta,
+            A,
+            B,
+            C,
+            D,
+            z,
+            delta_bias,
+            dout,
+            x,
+            out,
+            None,
+            ctx.delta_softplus,
+            False,  # option to recompute out_z, not used here
         )
         dz = rest[0] if ctx.has_z else None
         dB = dB.squeeze(1) if getattr(ctx, "squeeze_B", False) else dB
         dC = dC.squeeze(1) if getattr(ctx, "squeeze_C", False) else dC
-        return (du, ddelta, dA, dB, dC,
-                dD if D is not None else None,
-                dz,
-                ddelta_bias if delta_bias is not None else None,
-                None,
-                None)
+        return (
+            du,
+            ddelta,
+            dA,
+            dB,
+            dC,
+            dD if D is not None else None,
+            dz,
+            ddelta_bias if delta_bias is not None else None,
+            None,
+            None,
+        )
 
 
-def selective_scan_fn(u, delta, A, B, C, D=None, z=None, delta_bias=None, delta_softplus=False,
-                     return_last_state=False):
+def selective_scan_fn(
+    u, delta, A, B, C, D=None, z=None, delta_bias=None, delta_softplus=False, return_last_state=False
+):
     """if return_last_state is True, returns (out, last_state)
     last_state has shape (batch, dim, dstate). Note that the gradient of the last state is
     not considered in the backward pass.
@@ -88,8 +104,9 @@ def selective_scan_fn(u, delta, A, B, C, D=None, z=None, delta_bias=None, delta_
     return SelectiveScanFn.apply(u, delta, A, B, C, D, z, delta_bias, delta_softplus, return_last_state)
 
 
-def selective_scan_ref(u, delta, A, B, C, D=None, z=None, delta_bias=None, delta_softplus=False,
-                      return_last_state=False):
+def selective_scan_ref(
+    u, delta, A, B, C, D=None, z=None, delta_bias=None, delta_softplus=False, return_last_state=False
+):
     """
     u: r(B D L)
     delta: r(B D L)
@@ -123,33 +140,33 @@ def selective_scan_ref(u, delta, A, B, C, D=None, z=None, delta_bias=None, delta
         C = C.float()
     x = A.new_zeros((batch, dim, dstate))
     ys = []
-    deltaA = torch.exp(torch.einsum('bdl,dn->bdln', delta, A))
+    deltaA = torch.exp(torch.einsum("bdl,dn->bdln", delta, A))
     if not is_variable_B:
-        deltaB_u = torch.einsum('bdl,dn,bdl->bdln', delta, B, u)
+        deltaB_u = torch.einsum("bdl,dn,bdl->bdln", delta, B, u)
     else:
         if B.dim() == 3:
-            deltaB_u = torch.einsum('bdl,bnl,bdl->bdln', delta, B, u)
+            deltaB_u = torch.einsum("bdl,bnl,bdl->bdln", delta, B, u)
         else:
             B = repeat(B, "B G N L -> B (G H) N L", H=dim // B.shape[1])
-            deltaB_u = torch.einsum('bdl,bdnl,bdl->bdln', delta, B, u)
+            deltaB_u = torch.einsum("bdl,bdnl,bdl->bdln", delta, B, u)
     if is_variable_C and C.dim() == 4:
         C = repeat(C, "B G N L -> B (G H) N L", H=dim // C.shape[1])
     last_state = None
     for i in range(u.shape[2]):
         x = deltaA[:, :, i] * x + deltaB_u[:, :, i]
         if not is_variable_C:
-            y = torch.einsum('bdn,dn->bd', x, C)
+            y = torch.einsum("bdn,dn->bd", x, C)
         else:
             if C.dim() == 3:
-                y = torch.einsum('bdn,bn->bd', x, C[:, :, i])
+                y = torch.einsum("bdn,bn->bd", x, C[:, :, i])
             else:
-                y = torch.einsum('bdn,bdn->bd', x, C[:, :, :, i])
+                y = torch.einsum("bdn,bdn->bd", x, C[:, :, :, i])
         if i == u.shape[2] - 1:
             last_state = x
         if y.is_complex():
             y = y.real * 2
         ys.append(y)
-    y = torch.stack(ys, dim=2) # (batch dim L)
+    y = torch.stack(ys, dim=2)  # (batch dim L)
     out = y if D is None else y + u * rearrange(D, "d -> d 1")
     if z is not None:
         out = out * F.silu(z)
@@ -158,15 +175,29 @@ def selective_scan_ref(u, delta, A, B, C, D=None, z=None, delta_bias=None, delta
 
 
 class MambaInnerFn(torch.autograd.Function):
-
     @staticmethod
     @custom_fwd
-    def forward(ctx, xz, conv1d_weight, conv1d_bias, x_proj_weight, delta_proj_weight,
-                out_proj_weight, out_proj_bias,
-                A, B=None, C=None, D=None, delta_bias=None, B_proj_bias=None,
-                C_proj_bias=None, delta_softplus=True, checkpoint_lvl=1):
+    def forward(
+        ctx,
+        xz,
+        conv1d_weight,
+        conv1d_bias,
+        x_proj_weight,
+        delta_proj_weight,
+        out_proj_weight,
+        out_proj_bias,
+        A,
+        B=None,
+        C=None,
+        D=None,
+        delta_bias=None,
+        B_proj_bias=None,
+        C_proj_bias=None,
+        delta_softplus=True,
+        checkpoint_lvl=1,
+    ):
         """
-             xz: (batch, dim, seqlen)
+        xz: (batch, dim, seqlen)
         """
         assert causal_conv1d_cuda is not None, "causal_conv1d_cuda is not available. Please install causal-conv1d."
         assert checkpoint_lvl in [0, 1]
@@ -177,27 +208,26 @@ class MambaInnerFn(torch.autograd.Function):
             x_proj_weight = x_proj_weight.to(dtype=torch.get_autocast_gpu_dtype())
             delta_proj_weight = delta_proj_weight.to(dtype=torch.get_autocast_gpu_dtype())
             out_proj_weight = out_proj_weight.to(dtype=torch.get_autocast_gpu_dtype())
-            out_proj_bias = (out_proj_bias.to(dtype=torch.get_autocast_gpu_dtype())
-                             if out_proj_bias is not None else None)
+            out_proj_bias = (
+                out_proj_bias.to(dtype=torch.get_autocast_gpu_dtype()) if out_proj_bias is not None else None
+            )
         if xz.stride(-1) != 1:
             xz = xz.contiguous()
         conv1d_weight = rearrange(conv1d_weight, "d 1 w -> d w")
         x, z = xz.chunk(2, dim=1)
         conv1d_bias = conv1d_bias.contiguous() if conv1d_bias is not None else None
-        conv1d_out = causal_conv1d_cuda.causal_conv1d_fwd(
-            x, conv1d_weight, conv1d_bias, None, None, None, True
-        )
+        conv1d_out = causal_conv1d_cuda.causal_conv1d_fwd(x, conv1d_weight, conv1d_bias, None, None, None, True)
         # We're being very careful here about the layout, to avoid extra transposes.
         # We want delta to have d as the slowest moving dimension
         # and L as the fastest moving dimension, since those are what the ssm_scan kernel expects.
-        x_dbl = F.linear(rearrange(conv1d_out, 'b d l -> (b l) d'), x_proj_weight)  # (bl d)
-        delta = rearrange(delta_proj_weight @ x_dbl[:, :delta_rank].t(), "d (b l) -> b d l", l = L)
+        x_dbl = F.linear(rearrange(conv1d_out, "b d l -> (b l) d"), x_proj_weight)  # (bl d)
+        delta = rearrange(delta_proj_weight @ x_dbl[:, :delta_rank].t(), "d (b l) -> b d l", l=L)
         ctx.is_variable_B = B is None
         ctx.is_variable_C = C is None
         ctx.B_proj_bias_is_None = B_proj_bias is None
         ctx.C_proj_bias_is_None = C_proj_bias is None
         if B is None:  # variable B
-            B = x_dbl[:, delta_rank:delta_rank + d_state]  # (bl dstate)
+            B = x_dbl[:, delta_rank : delta_rank + d_state]  # (bl dstate)
             if B_proj_bias is not None:
                 B = B + B_proj_bias.to(dtype=B.dtype)
             if not A.is_complex():
@@ -230,9 +260,24 @@ class MambaInnerFn(torch.autograd.Function):
         ctx.checkpoint_lvl = checkpoint_lvl
         if checkpoint_lvl >= 1:  # Will recompute conv1d_out and delta in the backward pass
             conv1d_out, delta = None, None
-        ctx.save_for_backward(xz, conv1d_weight, conv1d_bias, x_dbl, x_proj_weight,
-                              delta_proj_weight, out_proj_weight, conv1d_out, delta,
-                              A, B, C, D, delta_bias, scan_intermediates, out)
+        ctx.save_for_backward(
+            xz,
+            conv1d_weight,
+            conv1d_bias,
+            x_dbl,
+            x_proj_weight,
+            delta_proj_weight,
+            out_proj_weight,
+            conv1d_out,
+            delta,
+            A,
+            B,
+            C,
+            D,
+            delta_bias,
+            scan_intermediates,
+            out,
+        )
         return F.linear(rearrange(out_z, "b d l -> b l d"), out_proj_weight, out_proj_bias)
 
     @staticmethod
@@ -240,8 +285,24 @@ class MambaInnerFn(torch.autograd.Function):
     def backward(ctx, dout):
         # dout: (batch, seqlen, dim)
         assert causal_conv1d_cuda is not None, "causal_conv1d_cuda is not available. Please install causal-conv1d."
-        (xz, conv1d_weight, conv1d_bias, x_dbl, x_proj_weight, delta_proj_weight, out_proj_weight,
-         conv1d_out, delta, A, B, C, D, delta_bias, scan_intermediates, out) = ctx.saved_tensors
+        (
+            xz,
+            conv1d_weight,
+            conv1d_bias,
+            x_dbl,
+            x_proj_weight,
+            delta_proj_weight,
+            out_proj_weight,
+            conv1d_out,
+            delta,
+            A,
+            B,
+            C,
+            D,
+            delta_bias,
+            scan_intermediates,
+            out,
+        ) = ctx.saved_tensors
         L = xz.shape[-1]
         delta_rank = delta_proj_weight.shape[1]
         d_state = A.shape[-1] * (1 if not A.is_complex() else 2)
@@ -249,11 +310,8 @@ class MambaInnerFn(torch.autograd.Function):
         if dout.stride(-1) != 1:
             dout = dout.contiguous()
         if ctx.checkpoint_lvl == 1:
-            conv1d_out = causal_conv1d_cuda.causal_conv1d_fwd(
-                x, conv1d_weight, conv1d_bias, None, None, None, True
-            )
-            delta = rearrange(delta_proj_weight @ x_dbl[:, :delta_rank].t(),
-                              "d (b l) -> b d l", l = L)
+            conv1d_out = causal_conv1d_cuda.causal_conv1d_fwd(x, conv1d_weight, conv1d_bias, None, None, None, True)
+            delta = rearrange(delta_proj_weight @ x_dbl[:, :delta_rank].t(), "d (b l) -> b d l", l=L)
         # The kernel supports passing in a pre-allocated dz (e.g., in case we want to fuse the
         # backward of selective_scan_cuda with the backward of chunk).
         dxz = torch.empty_like(xz)  # (batch, dim, seqlen)
@@ -261,9 +319,20 @@ class MambaInnerFn(torch.autograd.Function):
         dout = rearrange(dout, "b l e -> e (b l)")
         dout_y = rearrange(out_proj_weight.t() @ dout, "d (b l) -> b d l", l=L)
         dconv1d_out, ddelta, dA, dB, dC, dD, ddelta_bias, dz, out_z = selective_scan_cuda.bwd(
-            conv1d_out, delta, A, B, C, D, z, delta_bias, dout_y, scan_intermediates, out, dz,
+            conv1d_out,
+            delta,
+            A,
+            B,
+            C,
+            D,
+            z,
+            delta_bias,
+            dout_y,
+            scan_intermediates,
+            out,
+            dz,
             ctx.delta_softplus,
-            True  # option to recompute out_z
+            True,  # option to recompute out_z
         )
         dout_proj_weight = torch.einsum("eB,dB->ed", dout, rearrange(out_z, "b d l -> d (b l)"))
         dout_proj_bias = dout.sum(dim=(0, 1)) if not ctx.out_proj_bias_is_None else None
@@ -276,7 +345,7 @@ class MambaInnerFn(torch.autograd.Function):
             else:
                 dB = rearrange(dB, "b 1 dstate (l two) -> (b l) (dstate two)", two=2).contiguous()
             dB_proj_bias = dB.sum(0) if not ctx.B_proj_bias_is_None else None
-            dx_dbl[:, delta_rank:delta_rank + d_state] = dB  # (bl d)
+            dx_dbl[:, delta_rank : delta_rank + d_state] = dB  # (bl d)
             dB = None
         dC_proj_bias = None
         if ctx.is_variable_C:
@@ -301,29 +370,77 @@ class MambaInnerFn(torch.autograd.Function):
         )
         dconv1d_bias = dconv1d_bias if conv1d_bias is not None else None
         dconv1d_weight = rearrange(dconv1d_weight, "d w -> d 1 w")
-        return (dxz, dconv1d_weight, dconv1d_bias, dx_proj_weight, ddelta_proj_weight,
-                dout_proj_weight, dout_proj_bias,
-                dA, dB, dC, dD,
-                ddelta_bias if delta_bias is not None else None,
-                dB_proj_bias, dC_proj_bias, None)
+        return (
+            dxz,
+            dconv1d_weight,
+            dconv1d_bias,
+            dx_proj_weight,
+            ddelta_proj_weight,
+            dout_proj_weight,
+            dout_proj_bias,
+            dA,
+            dB,
+            dC,
+            dD,
+            ddelta_bias if delta_bias is not None else None,
+            dB_proj_bias,
+            dC_proj_bias,
+            None,
+        )
 
 
 def mamba_inner_fn(
-    xz, conv1d_weight, conv1d_bias, x_proj_weight, delta_proj_weight,
-    out_proj_weight, out_proj_bias,
-    A, B=None, C=None, D=None, delta_bias=None, B_proj_bias=None,
-    C_proj_bias=None, delta_softplus=True
+    xz,
+    conv1d_weight,
+    conv1d_bias,
+    x_proj_weight,
+    delta_proj_weight,
+    out_proj_weight,
+    out_proj_bias,
+    A,
+    B=None,
+    C=None,
+    D=None,
+    delta_bias=None,
+    B_proj_bias=None,
+    C_proj_bias=None,
+    delta_softplus=True,
 ):
-    return MambaInnerFn.apply(xz, conv1d_weight, conv1d_bias, x_proj_weight, delta_proj_weight,
-                              out_proj_weight, out_proj_bias,
-                              A, B, C, D, delta_bias, B_proj_bias, C_proj_bias, delta_softplus)
+    return MambaInnerFn.apply(
+        xz,
+        conv1d_weight,
+        conv1d_bias,
+        x_proj_weight,
+        delta_proj_weight,
+        out_proj_weight,
+        out_proj_bias,
+        A,
+        B,
+        C,
+        D,
+        delta_bias,
+        B_proj_bias,
+        C_proj_bias,
+        delta_softplus,
+    )
 
 
 def mamba_inner_ref(
-    xz, conv1d_weight, conv1d_bias, x_proj_weight, delta_proj_weight,
-    out_proj_weight, out_proj_bias,
-    A, B=None, C=None, D=None, delta_bias=None, B_proj_bias=None,
-    C_proj_bias=None, delta_softplus=True
+    xz,
+    conv1d_weight,
+    conv1d_bias,
+    x_proj_weight,
+    delta_proj_weight,
+    out_proj_weight,
+    out_proj_bias,
+    A,
+    B=None,
+    C=None,
+    D=None,
+    delta_bias=None,
+    B_proj_bias=None,
+    C_proj_bias=None,
+    delta_softplus=True,
 ):
     assert causal_conv1d_fn is not None, "causal_conv1d_fn is not available. Please install causal-conv1d."
     L = xz.shape[-1]
@@ -334,11 +451,11 @@ def mamba_inner_ref(
     # We're being very careful here about the layout, to avoid extra transposes.
     # We want delta to have d as the slowest moving dimension
     # and L as the fastest moving dimension, since those are what the ssm_scan kernel expects.
-    x_dbl = F.linear(rearrange(x, 'b d l -> (b l) d'), x_proj_weight)  # (bl d)
+    x_dbl = F.linear(rearrange(x, "b d l -> (b l) d"), x_proj_weight)  # (bl d)
     delta = delta_proj_weight @ x_dbl[:, :delta_rank].t()
     delta = rearrange(delta, "d (b l) -> b d l", l=L)
     if B is None:  # variable B
-        B = x_dbl[:, delta_rank:delta_rank + d_state]  # (bl d)
+        B = x_dbl[:, delta_rank : delta_rank + d_state]  # (bl d)
         if B_proj_bias is not None:
             B = B + B_proj_bias.to(dtype=B.dtype)
         if not A.is_complex():

--- a/src/modalities/models/mamba/ops/triton/selective_state_update.py
+++ b/src/modalities/models/mamba/ops/triton/selective_state_update.py
@@ -3,13 +3,11 @@
 """We want triton==2.1.0 or triton==2.2.0 or triton==2.3.0 for this
 """
 
-import math
+
 import torch
 import torch.nn.functional as F
-
 import triton
 import triton.language as tl
-
 from einops import rearrange, repeat
 
 
@@ -20,20 +18,52 @@ from einops import rearrange, repeat
 @triton.jit
 def _selective_scan_update_kernel(
     # Pointers to matrices
-    state_ptr, x_ptr, dt_ptr, dt_bias_ptr, A_ptr, B_ptr, C_ptr, D_ptr, z_ptr, out_ptr,
+    state_ptr,
+    x_ptr,
+    dt_ptr,
+    dt_bias_ptr,
+    A_ptr,
+    B_ptr,
+    C_ptr,
+    D_ptr,
+    z_ptr,
+    out_ptr,
     # Matrix dimensions
-    batch, nheads, dim, dstate, nheads_ngroups_ratio,
+    batch,
+    nheads,
+    dim,
+    dstate,
+    nheads_ngroups_ratio,
     # Strides
-    stride_state_batch, stride_state_head, stride_state_dim, stride_state_dstate,
-    stride_x_batch, stride_x_head, stride_x_dim,
-    stride_dt_batch, stride_dt_head, stride_dt_dim,
-    stride_dt_bias_head, stride_dt_bias_dim,
-    stride_A_head, stride_A_dim, stride_A_dstate,
-    stride_B_batch, stride_B_group, stride_B_dstate,
-    stride_C_batch, stride_C_group, stride_C_dstate,
-    stride_D_head, stride_D_dim,
-    stride_z_batch, stride_z_head, stride_z_dim,
-    stride_out_batch, stride_out_head, stride_out_dim,
+    stride_state_batch,
+    stride_state_head,
+    stride_state_dim,
+    stride_state_dstate,
+    stride_x_batch,
+    stride_x_head,
+    stride_x_dim,
+    stride_dt_batch,
+    stride_dt_head,
+    stride_dt_dim,
+    stride_dt_bias_head,
+    stride_dt_bias_dim,
+    stride_A_head,
+    stride_A_dim,
+    stride_A_dstate,
+    stride_B_batch,
+    stride_B_group,
+    stride_B_dstate,
+    stride_C_batch,
+    stride_C_group,
+    stride_C_dstate,
+    stride_D_head,
+    stride_D_dim,
+    stride_z_batch,
+    stride_z_head,
+    stride_z_dim,
+    stride_out_batch,
+    stride_out_head,
+    stride_out_dim,
     # Meta-parameters
     DT_SOFTPLUS: tl.constexpr,
     TIE_HDIM: tl.constexpr,
@@ -165,30 +195,63 @@ def selective_state_update(state, x, dt, A, B, C, D=None, z=None, dt_bias=None, 
     if dt_bias is not None:
         assert dt_bias.shape == (nheads, dim)
     out = torch.empty_like(x)
-    grid = lambda META: (triton.cdiv(dim, META['BLOCK_SIZE_M']), batch, nheads)
-    z_strides = ((z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0))
+
+    def grid(META):
+        return triton.cdiv(dim, META["BLOCK_SIZE_M"]), batch, nheads
+
+    z_strides = (z.stride(0), z.stride(1), z.stride(2)) if z is not None else (0, 0, 0)
     # We don't want autotune since it will overwrite the state
     # We instead tune by hand.
-    BLOCK_SIZE_M, num_warps = ((32, 4) if dstate <= 16
-                               else ((16, 4) if dstate <= 32 else
-                                     ((8, 4) if dstate <= 64 else
-                                      ((4, 4) if dstate <= 128 else
-                                       ((4, 8))))))
+    BLOCK_SIZE_M, num_warps = (
+        (32, 4)
+        if dstate <= 16
+        else ((16, 4) if dstate <= 32 else ((8, 4) if dstate <= 64 else ((4, 4) if dstate <= 128 else ((4, 8)))))
+    )
     tie_hdim = A.stride(-1) == 0 and A.stride(-2) == 0 and dt.stride(-1) == 0 and dt_bias.stride(-1) == 0
     with torch.cuda.device(x.device.index):
         _selective_scan_update_kernel[grid](
-            state, x, dt, dt_bias, A, B, C, D, z, out,
-            batch, nheads, dim, dstate, nheads // ngroups,
-            state.stride(0), state.stride(1), state.stride(2), state.stride(3),
-            x.stride(0), x.stride(1), x.stride(2),
-            dt.stride(0), dt.stride(1), dt.stride(2),
+            state,
+            x,
+            dt,
+            dt_bias,
+            A,
+            B,
+            C,
+            D,
+            z,
+            out,
+            batch,
+            nheads,
+            dim,
+            dstate,
+            nheads // ngroups,
+            state.stride(0),
+            state.stride(1),
+            state.stride(2),
+            state.stride(3),
+            x.stride(0),
+            x.stride(1),
+            x.stride(2),
+            dt.stride(0),
+            dt.stride(1),
+            dt.stride(2),
             *(dt_bias.stride(0), dt_bias.stride(1)) if dt_bias is not None else 0,
-            A.stride(0), A.stride(1), A.stride(2),
-            B.stride(0), B.stride(1), B.stride(2),
-            C.stride(0), C.stride(1), C.stride(2),
+            A.stride(0),
+            A.stride(1),
+            A.stride(2),
+            B.stride(0),
+            B.stride(1),
+            B.stride(2),
+            C.stride(0),
+            C.stride(1),
+            C.stride(2),
             *(D.stride(0), D.stride(1)) if D is not None else 0,
-            z_strides[0], z_strides[1], z_strides[2],
-            out.stride(0), out.stride(1), out.stride(2),
+            z_strides[0],
+            z_strides[1],
+            z_strides[2],
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
             dt_softplus,
             tie_hdim,
             BLOCK_SIZE_M,

--- a/src/modalities/models/model.py
+++ b/src/modalities/models/model.py
@@ -1,11 +1,10 @@
 from abc import abstractmethod
-from typing import Dict, List
+from typing import Dict
 
 import torch
 import torch.nn as nn
 
 from modalities.batch import DatasetBatch, InferenceResultBatch
-from transformers import PreTrainedTokenizer
 
 
 class NNModel(nn.Module):
@@ -20,7 +19,6 @@ class NNModel(nn.Module):
 
     def get_parameters(self) -> Dict[str, torch.Tensor]:
         return {name: param for name, param in self.named_parameters()}
-
 
 
 def model_predict_batch(model: nn.Module, batch: DatasetBatch) -> InferenceResultBatch:

--- a/src/modalities/registry/components.py
+++ b/src/modalities/registry/components.py
@@ -67,6 +67,7 @@ from modalities.models.huggingface.huggingface_models import (
     HuggingFacePretrainedModelConfig,
 )
 from modalities.models.mamba.mamba_config import MambaLLMConfig
+from modalities.models.mamba.mamba_model import MambaLLM
 from modalities.models.model_factory import ModelFactory
 from modalities.optimizers.lr_schedulers import DummyLRScheduler
 from modalities.optimizers.optimizer_factory import OptimizerFactory
@@ -81,8 +82,6 @@ from modalities.training.gradient_clipping.fsdp_gradient_clipper_config import (
     FSDPDummyGradientClipperConfig,
     FSDPGradientClipperConfig,
 )
-
-from modalities.models.mamba.mamba_model import MambaLLM
 
 
 @dataclass

--- a/src/modalities/running_env/fsdp/fsdp_auto_wrapper.py
+++ b/src/modalities/running_env/fsdp/fsdp_auto_wrapper.py
@@ -32,6 +32,7 @@ class FSDPTransformerAutoWrapPolicyFactory(FSDPAutoWrapFactoryIF):
                 block_type = FullyShardedDataParallelPlugin.get_module_class_from_name(model, cls_block_name)
             except AttributeError:
                 from accelerate.utils.dataclasses import get_module_class_from_name
+
                 block_type = get_module_class_from_name(model, cls_block_name)
             if block_type is None:
                 raise ValueError(f"Could not find block with name {cls_block_name} in model")

--- a/src/modalities/tokenization/tokenizer_wrapper.py
+++ b/src/modalities/tokenization/tokenizer_wrapper.py
@@ -19,7 +19,6 @@ class TokenizerWrapper(ABC):
     def get_token_id(self, token: str) -> int:
         raise NotImplementedError
 
-
     def get_token_id(self, token: str) -> int:
         raise NotImplementedError
 
@@ -46,11 +45,9 @@ class PreTrainedHFTokenizer(TokenizerWrapper):
         )["input_ids"]
         return tokens
 
-
     def decode(self, token_ids: List[int]) -> str:
         decoded_text = self.tokenizer.decode(token_ids)
         return decoded_text
-
 
     def get_token_id(self, token: str) -> int:
         token_id = self.tokenizer.convert_tokens_to_ids(token)

--- a/tests/config/test_component_factory.py
+++ b/tests/config/test_component_factory.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+from pydantic import BaseModel
 
 from modalities.config.component_factory import ComponentFactory
 from modalities.config.config import load_app_config_dict
@@ -109,9 +110,7 @@ def test_single_component(config_file_path: Path, component_factory: ComponentFa
 
     components = component_factory._build_config(config_dict=config_dict, component_names=component_names)
     assert "custom_comp_1" in components
-import pytest
-from pydantic import BaseModel
-from modalities.config.component_factory import ComponentFactory
+
 
 class TestComponentFactory:
     @pytest.fixture

--- a/tests/models/mamba/conftest.py
+++ b/tests/models/mamba/conftest.py
@@ -1,10 +1,10 @@
+from functools import partial
+
+import pytest
 import torch
 from torch import nn
 
-from modalities.models.mamba.mamba_block import MambaBlock, Block
-import pytest
-
-from functools import partial
+from modalities.models.mamba.mamba_block import Block, MambaBlock
 from modalities.models.mamba.mamba_config import MambaBlockConfig, MixerModelConfig
 from modalities.models.mamba.mamba_model import MambaLLM, MixerModel
 
@@ -125,39 +125,52 @@ def ssm_cfg(mamba_block_config):
 
 
 @pytest.fixture()
-def mamba_block_config(d_state,
-                       d_conv,
-                       expand,
-                       dt_rank,
-                       dt_min,
-                       dt_max,
-                       dt_init,
-                       dt_scale,
-                       dt_init_floor,
-                       conv_bias,
-                       bias,
-                       use_fast_path):
-    return MambaBlockConfig(d_state=d_state,
-                            d_conv=d_conv,
-                            expand=expand,
-                            dt_rank=dt_rank,
-                            dt_min=dt_min,
-                            dt_max=dt_max,
-                            dt_init=dt_init,
-                            dt_scale=dt_scale,
-                            dt_init_floor=dt_init_floor,
-                            conv_bias=conv_bias,
-                            bias=bias,
-                            use_fast_path=use_fast_path)
+def mamba_block_config(
+    d_state, d_conv, expand, dt_rank, dt_min, dt_max, dt_init, dt_scale, dt_init_floor, conv_bias, bias, use_fast_path
+):
+    return MambaBlockConfig(
+        d_state=d_state,
+        d_conv=d_conv,
+        expand=expand,
+        dt_rank=dt_rank,
+        dt_min=dt_min,
+        dt_max=dt_max,
+        dt_init=dt_init,
+        dt_scale=dt_scale,
+        dt_init_floor=dt_init_floor,
+        conv_bias=conv_bias,
+        bias=bias,
+        use_fast_path=use_fast_path,
+    )
 
 
 @pytest.fixture()
-def mixer_model(d_model, n_layer, vocab_size, norm_epsilon, rms_norm, initializer_cfg, fused_add_norm, residual_in_fp32,
-                device, dtype, mamba_block_config):
-    return MixerModel(d_model=d_model, n_layer=n_layer, vocab_size=vocab_size, norm_epsilon=norm_epsilon,
-                      rms_norm=rms_norm, initializer_cfg=initializer_cfg, fused_add_norm=fused_add_norm,
-                      residual_in_fp32=residual_in_fp32, device=device, dtype=dtype,
-                      mamba_block_config=mamba_block_config)
+def mixer_model(
+    d_model,
+    n_layer,
+    vocab_size,
+    norm_epsilon,
+    rms_norm,
+    initializer_cfg,
+    fused_add_norm,
+    residual_in_fp32,
+    device,
+    dtype,
+    mamba_block_config,
+):
+    return MixerModel(
+        d_model=d_model,
+        n_layer=n_layer,
+        vocab_size=vocab_size,
+        norm_epsilon=norm_epsilon,
+        rms_norm=rms_norm,
+        initializer_cfg=initializer_cfg,
+        fused_add_norm=fused_add_norm,
+        residual_in_fp32=residual_in_fp32,
+        device=device,
+        dtype=dtype,
+        mamba_block_config=mamba_block_config,
+    )
 
 
 @pytest.fixture()
@@ -186,19 +199,47 @@ def mixer_cls(layer_idx, factory_kwargs, ssm_cfg):
 
 
 @pytest.fixture()
-def mamba_block(d_model, d_state, d_conv, expand, dt_rank, dt_min, dt_max, dt_init, dt_init_floor, dt_scale,
-                bias, conv_bias, use_fast_path, layer_idx, dtype, device):
-    return MambaBlock(d_model=d_model, d_state=d_state, d_conv=d_conv, expand=expand, dt_rank=dt_rank,
-                      dt_min=dt_min, dt_max=dt_max, dt_init=dt_init, dt_scale=dt_scale, dt_init_floor=dt_init_floor,
-                      bias=bias, conv_bias=conv_bias, use_fast_path=use_fast_path, layer_idx=layer_idx, dtype=dtype,
-                      device=device)
+def mamba_block(
+    d_model,
+    d_state,
+    d_conv,
+    expand,
+    dt_rank,
+    dt_min,
+    dt_max,
+    dt_init,
+    dt_init_floor,
+    dt_scale,
+    bias,
+    conv_bias,
+    use_fast_path,
+    layer_idx,
+    dtype,
+    device,
+):
+    return MambaBlock(
+        d_model=d_model,
+        d_state=d_state,
+        d_conv=d_conv,
+        expand=expand,
+        dt_rank=dt_rank,
+        dt_min=dt_min,
+        dt_max=dt_max,
+        dt_init=dt_init,
+        dt_scale=dt_scale,
+        dt_init_floor=dt_init_floor,
+        bias=bias,
+        conv_bias=conv_bias,
+        use_fast_path=use_fast_path,
+        layer_idx=layer_idx,
+        dtype=dtype,
+        device=device,
+    )
 
 
 @pytest.fixture()
 def norm_cls(d_model, norm_epsilon, factory_kwargs):
-    return partial(
-        nn.LayerNorm, eps=norm_epsilon, **factory_kwargs
-    )
+    return partial(nn.LayerNorm, eps=norm_epsilon, **factory_kwargs)
 
 
 @pytest.fixture()
@@ -213,16 +254,20 @@ def residual_in_fp32():
 
 @pytest.fixture()
 def block(d_model, mixer_cls, norm_cls, fused_add_norm, residual_in_fp32):
-    return Block(d_model=d_model,
-                 mixer_cls=mixer_cls,
-                 norm_cls=norm_cls,
-                 fused_add_norm=fused_add_norm,
-                 residual_in_fp32=residual_in_fp32)
+    return Block(
+        d_model=d_model,
+        mixer_cls=mixer_cls,
+        norm_cls=norm_cls,
+        fused_add_norm=fused_add_norm,
+        residual_in_fp32=residual_in_fp32,
+    )
 
 
 @pytest.fixture()
-def hidden_states(d_model,
-                  batch_size, ):
+def hidden_states(
+    d_model,
+    batch_size,
+):
     return torch.randn(batch_size, 1, d_model)
 
 
@@ -247,13 +292,38 @@ def mixer_model_config(norm_epsilon, device, mamba_block_config):
 
 
 @pytest.fixture()
-def mamba_llm(d_model, n_layer, vocab_size, rms_norm, residual_in_fp32, fused_add_norm, prediction_key, sample_key,
-              seed, dtype, initializer_cfg, mixer_model_config):
-    return MambaLLM(d_model=d_model, n_layer=n_layer, vocab_size=vocab_size, rms_norm=rms_norm,
-                    residual_in_fp32=residual_in_fp32, fused_add_norm=fused_add_norm, pad_vocab_size_multiple=1,
-                    tie_embeddings=False, prediction_key=prediction_key, sample_key=sample_key, seed=seed, dtype=dtype,
-                    initializer_cfg=initializer_cfg, num_last_tokens=0, inference_params={},
-                    mixer_model_config=mixer_model_config)
+def mamba_llm(
+    d_model,
+    n_layer,
+    vocab_size,
+    rms_norm,
+    residual_in_fp32,
+    fused_add_norm,
+    prediction_key,
+    sample_key,
+    seed,
+    dtype,
+    initializer_cfg,
+    mixer_model_config,
+):
+    return MambaLLM(
+        d_model=d_model,
+        n_layer=n_layer,
+        vocab_size=vocab_size,
+        rms_norm=rms_norm,
+        residual_in_fp32=residual_in_fp32,
+        fused_add_norm=fused_add_norm,
+        pad_vocab_size_multiple=1,
+        tie_embeddings=False,
+        prediction_key=prediction_key,
+        sample_key=sample_key,
+        seed=seed,
+        dtype=dtype,
+        initializer_cfg=initializer_cfg,
+        num_last_tokens=0,
+        inference_params={},
+        mixer_model_config=mixer_model_config,
+    )
 
 
 @pytest.fixture()

--- a/tests/models/mamba/test_mamba_block.py
+++ b/tests/models/mamba/test_mamba_block.py
@@ -1,16 +1,11 @@
-import torch
 import pytest
+import torch
+
 from modalities.models.mamba.utils.generation import InferenceParams
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="We need cuda to run Mamba.")
-def test_mamba_block_forward(batch_size,
-                             sequence_length,
-                             d_model,
-                             d_state,
-                             d_conv,
-                             expand,
-                             mamba_block):
+def test_mamba_block_forward(batch_size, sequence_length, d_model, d_state, d_conv, expand, mamba_block):
     x = torch.randn(batch_size, sequence_length, d_model).to("cuda")
     mamba_block = mamba_block.to("cuda")
     y = mamba_block(x)
@@ -27,19 +22,17 @@ def test_block_forward(hidden_states, block):
     assert (hidden_states != computed_hidden_states).any()
 
 
-def test_get_states_from_cache(conv_state,
-                               ssm_state,
-                               batch_size,
-                               expand,
-                               d_model,
-                               d_state,
-                               d_conv,
-                               mamba_block,
-                               layer_idx
-                               ):
-    inference_params = InferenceParams(max_seqlen=16, max_batch_size=3, seqlen_offset=0, batch_size_offset=0,
-                                       key_value_memory_dict={layer_idx: (conv_state, ssm_state)},
-                                       lengths_per_sample=None)
+def test_get_states_from_cache(
+    conv_state, ssm_state, batch_size, expand, d_model, d_state, d_conv, mamba_block, layer_idx
+):
+    inference_params = InferenceParams(
+        max_seqlen=16,
+        max_batch_size=3,
+        seqlen_offset=0,
+        batch_size_offset=0,
+        key_value_memory_dict={layer_idx: (conv_state, ssm_state)},
+        lengths_per_sample=None,
+    )
     computed_conv_state, computed_ssm_state = mamba_block._get_states_from_cache(inference_params, batch_size)
     assert (conv_state == computed_conv_state).all()
     assert (ssm_state == computed_ssm_state).all()
@@ -55,7 +48,8 @@ def test_step(conv_state, ssm_state, mamba_block, hidden_states):
     computed_hidden_states, computed_conv_state, computed_ssm_state = mamba_block.step(
         hidden_states=hidden_states.detach().clone(),
         conv_state=conv_state.detach().clone(),
-        ssm_state=ssm_state.detach().clone())
+        ssm_state=ssm_state.detach().clone(),
+    )
     assert computed_hidden_states.shape == hidden_states.shape
     assert computed_conv_state.shape == conv_state.shape
     assert computed_ssm_state.shape == ssm_state.shape
@@ -67,8 +61,8 @@ def test_step(conv_state, ssm_state, mamba_block, hidden_states):
 def test_allocate_inference_cache(mamba_block, batch_size, sequence_length, conv_state, ssm_state):
     device = "cuda"
     mamba_block.to(device)
-    computed_conv_state, computed_ssm_state = mamba_block.allocate_inference_cache(batch_size=batch_size,
-                                                                                   max_seqlen=sequence_length,
-                                                                                   dtype=torch.float32)
+    computed_conv_state, computed_ssm_state = mamba_block.allocate_inference_cache(
+        batch_size=batch_size, max_seqlen=sequence_length, dtype=torch.float32
+    )
     assert (computed_conv_state == torch.zeros(conv_state.shape).to(device)).all()
     assert (computed_ssm_state == torch.zeros(ssm_state.shape).to(device)).all()

--- a/tests/models/mamba/test_mamba_model.py
+++ b/tests/models/mamba/test_mamba_model.py
@@ -1,8 +1,7 @@
 import pytest
 import torch
-from transformers import AutoTokenizer
-from modalities.models.mamba.mamba_model import _init_weights, create_block, MambaLLM
-from tests.conftest import _ROOT_DIR
+
+from modalities.models.mamba.mamba_model import _init_weights, create_block
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="We need cuda to run Mamba.")
@@ -40,11 +39,20 @@ def test_mamba_llm_forward(mamba_llm, batch_size, sequence_length, vocab_size, p
     assert y[prediction_key].shape == (batch_size, sequence_length, vocab_size)
 
 
-def test__create_block(d_model, ssm_cfg, norm_epsilon, rms_norm, residual_in_fp32, fused_add_norm, layer_idx, device,
-                       dtype):
-    test_block = create_block(d_model=d_model, ssm_cfg=ssm_cfg, norm_epsilon=norm_epsilon, rms_norm=rms_norm,
-                              residual_in_fp32=residual_in_fp32, fused_add_norm=fused_add_norm, layer_idx=layer_idx,
-                              device=device, dtype=dtype)
+def test__create_block(
+    d_model, ssm_cfg, norm_epsilon, rms_norm, residual_in_fp32, fused_add_norm, layer_idx, device, dtype
+):
+    test_block = create_block(
+        d_model=d_model,
+        ssm_cfg=ssm_cfg,
+        norm_epsilon=norm_epsilon,
+        rms_norm=rms_norm,
+        residual_in_fp32=residual_in_fp32,
+        fused_add_norm=fused_add_norm,
+        layer_idx=layer_idx,
+        device=device,
+        dtype=dtype,
+    )
     assert test_block.norm.normalized_shape[0] == d_model
     assert test_block.mixer.d_model == d_model
 

--- a/tests/test_yaml_configs/config_lorem_ipsum.yaml
+++ b/tests/test_yaml_configs/config_lorem_ipsum.yaml
@@ -157,9 +157,6 @@ checkpoint_saving:
         checkpoint_path: ${settings.paths.checkpointing_path}
         global_rank: ${settings.cuda_env.global_rank}
         experiment_id: ${settings.experiment_id} 
-        mixed_precision_settings: BF_16
-        sharding_strategy: FULL_SHARD
-        block_names: [GPT2Block]
 
 # resolving class types via different enums sucks...
 loss_fn:
@@ -270,7 +267,6 @@ batch_progress_subscriber:
   variant_key: rich
   config:
     local_rank: ${settings.cuda_env.local_rank}
-    world_size: ${settings.cuda_env.world_size}
     global_num_seen_steps: ${settings.training.global_num_seen_steps}
     train_dataloader:
       instance_key: train_dataloader


### PR DESCRIPTION
This PR fixes a few issues introduced mainly (but not exclusively) by #113:
- missing dependencies for Mamba (ce9d3fe)
- failed unit tests due to outdated test config files (fe439ca)
- global reformatting / linting, mainly of Mamba-related modules (e86fd86). 

The last change was probably necessary as the pre-commits in `pyproject.toml` had been commented out in #113, see [here](https://github.com/Modalities/modalities/pull/113/commits/1c90de3e71c3ea483f427eddf233bbe449c3c5f0#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711).