### PR TITLE
Unified unit & end-to-end testing

### DIFF
--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -53,7 +53,7 @@ def test(devices: Tuple[int], e2e_only: bool = False):
     """
     devices = devices if len(devices) <= 2 else devices[:2]  # use max 2 devices
     test_flags = {
-        "cpu": True,
+        "cpu": e2e_only is False,
         "gpu_single": len(devices) >= 1 and e2e_only is False,
         "gpu_multiple": len(devices) == 2,
     }
@@ -68,8 +68,8 @@ def test(devices: Tuple[int], e2e_only: bool = False):
     )
 
     # run unit tests
-    if test_flags["gpu_single"]:
-        command_unit_tests = f"CUDA_VISIBLE_DEVICES={devices[0]} pytest"
+    if e2e_only is False:
+        command_unit_tests = f"CUDA_VISIBLE_DEVICES={devices[0] if len(devices) > 0 else None} pytest"
 
         print("\n=== RUN UNIT TESTS ===")
         print(command_unit_tests)

--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -53,8 +53,8 @@ def test(devices: Tuple[int], e2e_only: bool = False):
     """
     devices = devices if len(devices) <= 2 else devices[:2]  # use max 2 devices
     test_flags = {
-        "cpu": e2e_only is False,
-        "gpu_single": len(devices) >= 1 and e2e_only is False,
+        "cpu": not e2e_only,
+        "gpu_single": len(devices) >= 1 and not e2e_only,
         "gpu_multiple": len(devices) == 2,
     }
     print(f"> UNIT       TESTS ON          CPU: {test_flags['cpu']}")
@@ -68,7 +68,7 @@ def test(devices: Tuple[int], e2e_only: bool = False):
     )
 
     # run unit tests
-    if e2e_only is False:
+    if not e2e_only:
         command_unit_tests = f"CUDA_VISIBLE_DEVICES={devices[0] if len(devices) > 0 else None} pytest"
 
         print("\n=== RUN UNIT TESTS ===")

--- a/src/modalities/checkpointing/fsdp/fsdp_checkpoint_loading.py
+++ b/src/modalities/checkpointing/fsdp/fsdp_checkpoint_loading.py
@@ -58,7 +58,8 @@ class FSDPCheckpointLoading(CheckpointLoadingIF):
         )
         return fsdp_model
 
-    def load_optimizer_checkpoint(self, optimizer: Optimizer, wrapped_model: FSDP, file_path: Path) -> Optimizer:
+    def load_optimizer_checkpoint(self, optimizer: Optimizer, model: FSDP, file_path: Path) -> Optimizer:
+        # NOTE: model must be FSDP-wrapped model!
         # load optimizer
         full_optimizer_state_dict = None
         if self.global_rank == 0:
@@ -67,7 +68,7 @@ class FSDPCheckpointLoading(CheckpointLoadingIF):
 
         # distribute the optimizer state dict from rank 0 to all the other ranks
         sharded_optimizer_state_dict = FSDP.scatter_full_optim_state_dict(
-            full_optim_state_dict=full_optimizer_state_dict, model=wrapped_model, group=None
+            full_optim_state_dict=full_optimizer_state_dict, model=model, group=None
         )
         optimizer.load_state_dict(sharded_optimizer_state_dict)
 

--- a/src/modalities/dataloader/dataloader_factory.py
+++ b/src/modalities/dataloader/dataloader_factory.py
@@ -30,10 +30,9 @@ class DataloaderFactory:
             pin_memory (bool): Boolean flag for pinning memory
             shuffle (bool): Boolean flag for shuffling the dataset
             skip_num_batches (Optional[int], optional): Defines the number of batches to skip.
-              NOTE: The checkpoints are indexed with training steps (number of backward passes).
-              The number of seen lcoal batches must not be confused with the number of micro steps
-              which is the number of forward passes
-              (i.e, local num seen batches = num train steps * gradient accumulation steps).
+              NOTE: The checkpoints are indexed with training steps (i.e., number of optimizer steps).
+              skip_num_batches must not be confused with the number of optimizer steps!
+              skip_num_batches = num optimizer steps * gradient accumulation steps
               Defaults to 0.
 
         Returns:

--- a/src/modalities/optimizers/optimizer_factory.py
+++ b/src/modalities/optimizers/optimizer_factory.py
@@ -1,4 +1,5 @@
 import re
+from pathlib import Path
 from typing import Dict, List, Tuple
 
 import torch.nn as nn
@@ -40,7 +41,7 @@ class OptimizerFactory:
 
     @staticmethod
     def get_checkpointed_optimizer(
-        checkpoint_loading: CheckpointLoadingIF, checkpoint_path, wrapped_model: nn.Module, optimizer: Optimizer
+        checkpoint_loading: CheckpointLoadingIF, checkpoint_path: Path, wrapped_model: nn.Module, optimizer: Optimizer
     ) -> Optimizer:
         wrapped_optimizer = checkpoint_loading.load_optimizer_checkpoint(
             file_path=checkpoint_path, optimizer=optimizer, model=wrapped_model

--- a/src/modalities/running_env/cuda_env.py
+++ b/src/modalities/running_env/cuda_env.py
@@ -21,5 +21,8 @@ class CudaEnv:
         return self
 
     def __exit__(self, type, value, traceback):
-        dist.barrier()
+        # TODO and NOTE:
+        # when we call barrier here and one of the ranks fails, we get stuck here.
+        # In the future, we should probably add a timeout here and handle the case when one of the ranks fails.
+        # dist.barrier()
         dist.destroy_process_group()

--- a/tests/checkpointing/gpt2_config.yaml
+++ b/tests/checkpointing/gpt2_config.yaml
@@ -23,6 +23,7 @@ model:
             n_embd: ${model.config.n_embd}
             n_head: ${model.config.n_head_q} #it has to be head_q here
             seq_length_dim: -2
+    attention_implementation: manual
     activation_type: gelu
     weight_init:
       mean: 0.0

--- a/tests/checkpointing/test_fsdp_to_disc_checkpointing.py
+++ b/tests/checkpointing/test_fsdp_to_disc_checkpointing.py
@@ -254,7 +254,7 @@ class TestFSDPToDiscCheckpointing:
             entity_type=CheckpointingEntityType.OPTIMIZER,
         )
         checkpoint_loading.load_optimizer_checkpoint(
-            optimizer=optimizer_2, wrapped_model=fsdp_wrapped_model_2, file_path=optimizer_checkpointing_path
+            optimizer=optimizer_2, model=fsdp_wrapped_model_2, file_path=optimizer_checkpointing_path
         )
 
         loaded_and_updated_model_parameters = self._clone_parameters(fsdp_wrapped_model)

--- a/tests/checkpointing/test_fsdp_to_disc_checkpointing.py
+++ b/tests/checkpointing/test_fsdp_to_disc_checkpointing.py
@@ -26,6 +26,7 @@ from modalities.registry.components import COMPONENTS
 from modalities.registry.registry import Registry
 from modalities.running_env.cuda_env import CudaEnv
 from modalities.running_env.env_utils import MixedPrecisionSettings
+from modalities.utils.number_conversion import NumberConversion
 
 # NOTE: We need to run the tests in a torch distributed environment with at least two GPUs.
 # CUDA_VISIBLE_DEVICES=0,1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 \
@@ -83,7 +84,12 @@ class TestFSDPToDiscCheckpointing:
     @pytest.fixture
     def optimizer(self, fsdp_wrapped_model: nn.Module) -> Optimizer:
         optimizer = OptimizerFactory.get_adam_w(
-            wrapped_model=fsdp_wrapped_model, lr=0.001, betas=[0.9, 0.95], eps=1e-8, weight_decay=1e-1
+            wrapped_model=fsdp_wrapped_model,
+            lr=0.001,
+            betas=[0.9, 0.95],
+            eps=1e-8,
+            weight_decay=1e-1,
+            weight_decay_groups_excluded=[],
         )
         return optimizer
 
@@ -96,6 +102,10 @@ class TestFSDPToDiscCheckpointing:
     def cuda_env_context(self):
         with CudaEnv(process_group_backend=ProcessGroupBackendType.nccl):
             yield
+
+    @staticmethod
+    def _clone_parameters(fsdp_wrapped_model):
+        return [p.clone() for p in fsdp_wrapped_model.parameters() if p.requires_grad and p.numel() > 0]
 
     @staticmethod
     def _generate_batch(gpt2_model_config: Dict):
@@ -139,9 +149,13 @@ class TestFSDPToDiscCheckpointing:
         optimizer_1_state_dict: Dict, optimizer_2_state_dict: Dict, must_be_equal: bool
     ):
         if must_be_equal:
-            assert optimizer_1_state_dict["param_groups"] == optimizer_2_state_dict["param_groups"]
+            assert (
+                optimizer_1_state_dict["param_groups"] == optimizer_2_state_dict["param_groups"]
+            ), "_assert_equality_optimizer_param_group failed (must_be_equal = True)"
         else:
-            assert not (optimizer_1_state_dict["param_groups"] == optimizer_2_state_dict["param_groups"])
+            assert not (
+                optimizer_1_state_dict["param_groups"] == optimizer_2_state_dict["param_groups"]
+            ), "_assert_equality_optimizer_param_group failed (must_be_equal = False)"
 
     @staticmethod
     def _assert_equality_optimizer_state(
@@ -157,17 +171,21 @@ class TestFSDPToDiscCheckpointing:
             assert set(state_1.keys()) == set(state_2.keys())
             for state_key in state_1.keys():
                 if must_be_equal:
-                    assert torch.equal(state_1[state_key], state_2[state_key])
+                    assert torch.equal(
+                        state_1[state_key], state_2[state_key]
+                    ), "_assert_equality_optimizer_state failed (must_be_equal = True)"
                 else:
-                    assert not torch.equal(state_1[state_key], state_2[state_key])
+                    assert not torch.equal(
+                        state_1[state_key], state_2[state_key]
+                    ), "_assert_equality_optimizer_state failed (must_be_equal = False)"
 
     @staticmethod
     def _assert_equality_two_models(params_1, params_2, must_be_equal: bool):
         for p1, p2 in zip(params_1, params_2):
             if must_be_equal:
-                assert torch.equal(p1, p2)
+                assert torch.equal(p1, p2), "_assert_equality_two_models failed (must_be_equal = True)"
             else:
-                assert not torch.equal(p1, p2)
+                assert not torch.equal(p1, p2), "_assert_equality_two_models failed (must_be_equal = False)"
 
     def test_save_checkpoint_after_backward_pass(
         self,
@@ -180,8 +198,15 @@ class TestFSDPToDiscCheckpointing:
         experiment_id = "0"
         num_train_steps_done = 1
 
+        context_size = gpt2_model_config_dict["model"]["config"]["block_size"]
+        get_num_tokens_from_num_steps_callable = NumberConversion.get_num_tokens_from_num_steps_callable(
+            num_ranks=2, local_micro_batch_size=4, context_size=context_size
+        )
         checkpoint_saving = FSDPCheckpointSaving(
-            checkpoint_path=temporary_checkpoint_folder_path, experiment_id=experiment_id, global_rank=dist.get_rank()
+            checkpoint_path=temporary_checkpoint_folder_path,
+            experiment_id=experiment_id,
+            global_rank=dist.get_rank(),
+            get_num_tokens_from_num_steps_callable=get_num_tokens_from_num_steps_callable,
         )
 
         checkpoint_loading = FSDPCheckpointLoading(
@@ -191,7 +216,7 @@ class TestFSDPToDiscCheckpointing:
             sharding_strategy=ShardingStrategy.FULL_SHARD,
         )
 
-        untrained_model_parameters = [p.clone() for p in fsdp_wrapped_model.parameters()]
+        untrained_model_parameters = self._clone_parameters(fsdp_wrapped_model)
         untrained_optimizer_state_dict = deepcopy(optimizer.state_dict())
 
         # run backward pass
@@ -203,7 +228,7 @@ class TestFSDPToDiscCheckpointing:
             batch_input_ids_dict=batch_input_ids_dict,
             batch_target_ids=batch_target_ids,
         )
-        updated_model_parameters = [p.clone() for p in fsdp_wrapped_model.parameters()]
+        updated_model_parameters = self._clone_parameters(fsdp_wrapped_model)
         updated_optimizer_state_dict = deepcopy(optimizer.state_dict())
 
         # save model and optimizer before backward pass
@@ -232,7 +257,7 @@ class TestFSDPToDiscCheckpointing:
             optimizer=optimizer_2, wrapped_model=fsdp_wrapped_model_2, file_path=optimizer_checkpointing_path
         )
 
-        loaded_and_updated_model_parameters = [p.clone() for p in fsdp_wrapped_model_2.parameters()]
+        loaded_and_updated_model_parameters = self._clone_parameters(fsdp_wrapped_model)
         loaded_and_updated_optimizer_state_dict = deepcopy(optimizer_2.state_dict())
 
         # make sure that after the update all weights are DIFFERENT from the original ones
@@ -272,7 +297,7 @@ class TestFSDPToDiscCheckpointing:
             batch_target_ids=batch_target_ids,
         )
 
-        assert loss_1 == loss_2
+        assert loss_1 == loss_2, f"loss_1 = {loss_1} does not equal loss_2 = {loss_2}"
 
         # make sure that after another update the two models and optimizers are the same
         self._assert_equality_two_models(

--- a/tests/checkpointing/torch/test_torch_checkpoint_loading.py
+++ b/tests/checkpointing/torch/test_torch_checkpoint_loading.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+import pytest
 import torch
 import torch.nn as nn
 
@@ -17,6 +18,7 @@ class DummyModel(nn.Module):
         return {"output": output}
 
 
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="This test requires 1 GPU.")
 def test_load_model_checkpoint(tmp_path):
     # After storing the state_dict on disc, the model state does not
     # contain any information about the device or precision
@@ -34,21 +36,20 @@ def test_load_model_checkpoint(tmp_path):
     torch.save(model_state, tmp_file_path)
 
     # load the model checkpoint with different settings
+    gpu_device = torch.device("cuda:0")
     loaded_model_1: DummyModel = TorchCheckpointLoading(
-        device=torch.device("cuda:1"), precision=PrecisionEnum.FP32
+        device=gpu_device, precision=PrecisionEnum.FP32
     ).load_model_checkpoint(model_2, tmp_file_path)
 
-    assert torch.equal(model_1._weights.weight.to("cuda:1"), loaded_model_1._weights.weight)
-    assert torch.equal(model_1._weights.bias.to("cuda:1"), loaded_model_1._weights.bias)
+    assert torch.equal(model_1._weights.weight.to(gpu_device), loaded_model_1._weights.weight)
+    assert torch.equal(model_1._weights.bias.to(gpu_device), loaded_model_1._weights.bias)
 
     # since we provided the precision, the model will be loaded with the specified precision
     # even if the state dict contains a different precision.
     assert loaded_model_1._weights.weight.dtype == torch.float32
-    assert loaded_model_1._weights.weight.device == torch.device("cuda:1")
+    assert loaded_model_1._weights.weight.device == gpu_device
 
     # if we don't specify the precision, the model will be loaded with the precision of the state dict.
     # In this case, BF16 is used as defined for model_1.
-    loaded_model_2: DummyModel = TorchCheckpointLoading(device=torch.device("cuda:1")).load_model_checkpoint(
-        model_3, tmp_file_path
-    )
+    loaded_model_2: DummyModel = TorchCheckpointLoading(device=gpu_device).load_model_checkpoint(model_3, tmp_file_path)
     assert loaded_model_2._weights.weight.dtype == torch.bfloat16

--- a/tests/dataloader/distributed/dist_dataloader_config_with_shuffling.yaml
+++ b/tests/dataloader/distributed/dist_dataloader_config_with_shuffling.yaml
@@ -12,7 +12,7 @@ train_dataloader:
     pin_memory: true
     shuffle: false
     dataloader_tag: "train"
-    skip_num_micro_steps: 0
+    skip_num_batches: 0
     dataset:
       instance_key: train_dataset
       pass_type: BY_REFERENCE

--- a/tests/dataloader/distributed/dist_dataloader_config_with_shuffling_and_skipped_batches.yaml
+++ b/tests/dataloader/distributed/dist_dataloader_config_with_shuffling_and_skipped_batches.yaml
@@ -12,7 +12,7 @@ train_dataloader:
     pin_memory: true
     shuffle: false
     dataloader_tag: "train"
-    skip_num_micro_steps: 1
+    skip_num_batches: 1
     dataset:
       instance_key: train_dataset
       pass_type: BY_REFERENCE

--- a/tests/dataloader/distributed/dist_dataloader_config_without_shuffling.yaml
+++ b/tests/dataloader/distributed/dist_dataloader_config_without_shuffling.yaml
@@ -12,7 +12,7 @@ train_dataloader:
     pin_memory: true
     shuffle: false
     dataloader_tag: "train"
-    skip_num_micro_steps: 0
+    skip_num_batches: 0
     dataset:
       instance_key: train_dataset
       pass_type: BY_REFERENCE

--- a/tests/dataloader/distributed/dist_repeating_dataloader_config_without_shuffling_but_skipped_batch.yaml
+++ b/tests/dataloader/distributed/dist_repeating_dataloader_config_without_shuffling_but_skipped_batch.yaml
@@ -18,7 +18,7 @@ train_dataloader:
         pin_memory: true
         shuffle: false
         dataloader_tag: "train"
-        skip_num_micro_steps: 1
+        skip_num_batches: 1
         dataset:
           instance_key: train_dataset
           pass_type: BY_REFERENCE

--- a/tests/end2end_tests/gpt2_train_num_steps_8.yaml
+++ b/tests/end2end_tests/gpt2_train_num_steps_8.yaml
@@ -83,6 +83,13 @@ checkpoint_saving:
         checkpoint_path: ${settings.paths.checkpointing_path} # TODO <replaced_in_test>
         global_rank: ${settings.cuda_env.global_rank}
         experiment_id: ${settings.experiment_id} 
+        get_num_tokens_from_num_steps_callable:
+          component_key: number_conversion
+          variant_key: num_tokens_from_num_steps_callable
+          config:
+            num_ranks: ${settings.cuda_env.world_size}
+            local_micro_batch_size: ${settings.training.local_train_micro_batch_size}
+            context_size: ${settings.training.sequence_length}        
 
 
 # resolving class types via different enums sucks...
@@ -128,6 +135,7 @@ model:
             n_embd: ${model.config.n_embd}
             n_head: ${model.config.n_head_q} #it has to be head_q here
             seq_length_dim: -2
+    attention_implementation: manual
     activation_type: gelu
     weight_init:
       mean: 0.0
@@ -170,6 +178,7 @@ optimizer:
     betas: [0.9, 0.95]
     eps: 1e-8
     weight_decay: 1e-1
+    weight_decay_groups_excluded: ["embedding", "layernorm"]
     wrapped_model: 
       instance_key: wrapped_model
       pass_type: BY_REFERENCE
@@ -189,6 +198,7 @@ batch_progress_subscriber:
   variant_key: rich
   config:
     local_rank: ${settings.cuda_env.local_rank}
+    world_size: ${settings.cuda_env.world_size}
     global_num_seen_steps:
       component_key: number_conversion
       variant_key: num_steps_from_num_tokens
@@ -197,6 +207,7 @@ batch_progress_subscriber:
         local_micro_batch_size: ${settings.training.local_train_micro_batch_size}
         global_num_tokens: ${settings.training.global_num_seen_tokens}
         context_size: ${settings.training.sequence_length}
+    gradient_acc_steps: ${settings.training.gradient_acc_steps}
     train_dataloader:
       instance_key: train_dataloader
       pass_type: BY_REFERENCE

--- a/tests/end2end_tests/gpt2_train_num_steps_8.yaml
+++ b/tests/end2end_tests/gpt2_train_num_steps_8.yaml
@@ -42,6 +42,13 @@ train_dataloader:
     pin_memory: true
     shuffle: false
     dataloader_tag: "train"
+    skip_num_batches: 
+      component_key: number_conversion
+      variant_key: local_num_batches_from_num_tokens
+      config:
+        num_ranks: ${settings.cuda_env.world_size}
+        global_num_tokens: ${settings.training.global_num_seen_tokens}
+        context_size: ${settings.training.sequence_length}
     dataset:
       instance_key: train_dataset
       pass_type: BY_REFERENCE
@@ -218,13 +225,3 @@ evaluation_subscriber:
   component_key: results_subscriber
   variant_key: save_all
   config: {}
-
-# evaluation_subscriber:
-#   component_key: results_subscriber
-#   variant_key: wandb
-#   config:
-#     local_rank: ${settings.cuda_env.local_rank}
-#     project: modalities_lorem_ipsum
-#     mode: ONLINE
-#     experiment_id: ${settings.experiment_id}
-#     directory: "."

--- a/tests/end2end_tests/gpt2_warm_start_from_step_4.yaml
+++ b/tests/end2end_tests/gpt2_warm_start_from_step_4.yaml
@@ -7,7 +7,7 @@ settings:
     training_log_interval_in_steps: 1
     checkpointing_interval_in_steps: 4
     evaluation_interval_in_steps: 1
-    global_num_seen_tokens: 4
+    global_num_seen_tokens:  2048 # 4 steps * 256 tokens per step * 2 ranks
     do_apply_activation_checkpointing: false
     gradient_acc_steps: 1
     local_train_micro_batch_size: 1
@@ -42,7 +42,13 @@ train_dataloader:
     pin_memory: true
     shuffle: false
     dataloader_tag: "train"
-    skip_num_micro_steps: ${settings.training.global_num_seen_tokens}
+    skip_num_batches:
+      component_key: number_conversion
+      variant_key: local_num_batches_from_num_tokens
+      config:
+        num_ranks: ${settings.cuda_env.world_size}
+        global_num_tokens: ${settings.training.global_num_seen_tokens}
+        context_size: ${settings.training.sequence_length}
     dataset:
       instance_key: train_dataset
       pass_type: BY_REFERENCE

--- a/tests/end2end_tests/gpt2_warm_start_from_step_4.yaml
+++ b/tests/end2end_tests/gpt2_warm_start_from_step_4.yaml
@@ -93,6 +93,13 @@ checkpoint_saving:
         checkpoint_path: ${settings.paths.checkpointing_path} # TODO <replaced_in_test>
         global_rank: ${settings.cuda_env.global_rank}
         experiment_id: ${settings.experiment_id} 
+        get_num_tokens_from_num_steps_callable:
+          component_key: number_conversion
+          variant_key: num_tokens_from_num_steps_callable
+          config:
+            num_ranks: ${settings.cuda_env.world_size}
+            local_micro_batch_size: ${settings.training.local_train_micro_batch_size}
+            context_size: ${settings.training.sequence_length}        
 
 # resolving class types via different enums sucks...
 loss_fn:
@@ -137,6 +144,7 @@ model:
             n_embd: ${model.config.n_embd}
             n_head: ${model.config.n_head_q} #it has to be head_q here
             seq_length_dim: -2
+    attention_implementation: manual
     activation_type: gelu
     weight_init:
       mean: 0.0
@@ -179,6 +187,7 @@ optimizer:
     betas: [0.9, 0.95]
     eps: 1e-8
     weight_decay: 1e-1
+    weight_decay_groups_excluded: ["embedding", "layernorm"]
     wrapped_model: 
       instance_key: wrapped_model
       pass_type: BY_REFERENCE
@@ -198,6 +207,7 @@ batch_progress_subscriber:
   variant_key: rich
   config:
     local_rank: ${settings.cuda_env.local_rank}
+    world_size: ${settings.cuda_env.world_size}
     global_num_seen_steps:
       component_key: number_conversion
       variant_key: num_steps_from_num_tokens
@@ -206,6 +216,7 @@ batch_progress_subscriber:
         local_micro_batch_size: ${settings.training.local_train_micro_batch_size}
         global_num_tokens: ${settings.training.global_num_seen_tokens}
         context_size: ${settings.training.sequence_length}
+    gradient_acc_steps: ${settings.training.gradient_acc_steps}
     train_dataloader:
       instance_key: train_dataloader
       pass_type: BY_REFERENCE

--- a/tests/end2end_tests/gpt2_warm_start_from_step_4.yaml
+++ b/tests/end2end_tests/gpt2_warm_start_from_step_4.yaml
@@ -125,7 +125,7 @@ wrapped_model:
     checkpoint_loading:
       instance_key: checkpoint_loading
       pass_type: BY_REFERENCE
-    checkpoint_path: tmp/checkpoints/0/eid_0-model-num_steps_4.bin
+    checkpoint_path: must_be_set_in_test_impl
 
 model:
   component_key: model
@@ -185,7 +185,22 @@ scheduler:
       instance_key: optimizer
       pass_type: BY_REFERENCE
 
-optimizer:  
+optimizer:
+  component_key: optimizer
+  variant_key: checkpointed
+  config:
+    optimizer:
+      instance_key: optimizer_original
+      pass_type: BY_REFERENCE
+    wrapped_model:
+      instance_key: wrapped_model
+      pass_type: BY_REFERENCE
+    checkpoint_loading:
+      instance_key: checkpoint_loading
+      pass_type: BY_REFERENCE
+    checkpoint_path: must_be_set_in_test_impl
+
+optimizer_original:  
   component_key: optimizer
   variant_key: adam_w
   config:
@@ -233,13 +248,3 @@ evaluation_subscriber:
   component_key: results_subscriber
   variant_key: save_all
   config: {}
-
-# evaluation_subscriber:
-#   component_key: results_subscriber
-#   variant_key: wandb
-#   config:
-#     local_rank: ${settings.cuda_env.local_rank}
-#     project: modalities_lorem_ipsum
-#     mode: ONLINE
-#     experiment_id: ${settings.experiment_id}
-#     directory: "."

--- a/tests/end2end_tests/test_fsdp_warmstart.py
+++ b/tests/end2end_tests/test_fsdp_warmstart.py
@@ -154,13 +154,15 @@ class TestWarmstart:
                     )
 
     def test_warmstart_dataloader(self):
+        # non-skipped config
         gpt2_two_steps_config_file_path = working_dir / "gpt2_train_num_steps_8.yaml"
         gpt2_two_steps_config_dict = load_app_config_dict(gpt2_two_steps_config_file_path)
         # adopt dataset path
         gpt2_two_steps_config_dict["train_dataset"]["config"]["raw_data_path"] = working_dir / "lorem_ipsum.pbin"
 
+        # skipped config
         gpt2_warm_start_from_step_1_config_file_path = working_dir / "gpt2_warm_start_from_step_4.yaml"
-        gpt2_warm_start_from_step_1_dict = load_app_config_dict(gpt2_two_steps_config_file_path)
+        gpt2_warm_start_from_step_1_dict = load_app_config_dict(gpt2_warm_start_from_step_1_config_file_path)
         # adopt dataset path
         gpt2_warm_start_from_step_1_dict["train_dataset"]["config"]["raw_data_path"] = working_dir / "lorem_ipsum.pbin"
 
@@ -189,10 +191,19 @@ class TestWarmstart:
             dl_2_samples = [s for s in dataloader_2]
 
             # fast forward the first dataloader
+
             num_skip_steps = dataloader_2.fast_forward_batch_id
+
+            # make sure that we actually skip as defined in the config
+            assert num_skip_steps == 4
+            assert len(dl_1_samples) == num_skip_steps + len(dl_2_samples)
+
+            # make sure that the first dataloader is not skipped
+            assert dataloader_1.fast_forward_batch_id == 0
 
             # iterate through both sample lists from the dataloaders
             # and assert the equality of the samples
+
             for i in range(len(dataloader_2)):
                 assert dl_1_samples[i + num_skip_steps].samples["input_ids"].equal(dl_2_samples[i].samples["input_ids"])
 

--- a/tests/models/test_causal_self_attention.py
+++ b/tests/models/test_causal_self_attention.py
@@ -34,6 +34,7 @@ def _get_random_attention_layer(n_head_q, n_head_kv, n_embd, attention_impl, att
     return self_attention_layer
 
 
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="This test requires 1 GPU.")
 @pytest.mark.parametrize(
     "n_head_q, n_head_kv, n_embd",
     [
@@ -159,6 +160,7 @@ def test_forward_pass_shapes(seq_length, n_head_q, n_head_kv, head_dim, attentio
     assert out.shape == (batch_size, seq_length, n_head_q, head_dim)
 
 
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="This test requires 1 GPU.")
 @pytest.mark.parametrize(
     "n_head_q, n_head_kv, n_embd, attention_impl_1, attention_impl_2, verbose",
     [

--- a/tests/run_distributed_tests.sh
+++ b/tests/run_distributed_tests.sh
@@ -1,23 +1,35 @@
 #!/bin/sh
 
-# Run pytest with torchrun
+#################
+### VARIABLES ###
+#################
+DEV0=3
+DEV1=4
+COVERAGE=--no-cov
 
+
+#############
+### TESTS ###
+#################
 # test_fsdp_to_disc_checkpointing
-CUDA_VISIBLE_DEVICES=0,1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) checkpointing/test_fsdp_to_disc_checkpointing.py
+CUDA_VISIBLE_DEVICES=$DEV0,$DEV1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) checkpointing/test_fsdp_to_disc_checkpointing.py $COVERAGE
 
 # test_fsdp_warmstart
-CUDA_VISIBLE_DEVICES=0,1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) end2end_tests/test_fsdp_warmstart.py -k "test_warm_start"
-CUDA_VISIBLE_DEVICES=0,1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) end2end_tests/test_fsdp_warmstart.py -k "test_warmstart_dataloader"
+CUDA_VISIBLE_DEVICES=$DEV0,$DEV1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) end2end_tests/test_fsdp_warmstart.py -k "test_warm_start" $COVERAGE
+CUDA_VISIBLE_DEVICES=$DEV0,$DEV1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) end2end_tests/test_fsdp_warmstart.py -k "test_warmstart_dataloader" $COVERAGE
 
 
 # test_distributed_repeating_dataloader
-CUDA_VISIBLE_DEVICES=0,1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) dataloader/distributed/test_distributed_repeating_dataloader.py -k "test_resumable_dataloader_without_shuffling"
+CUDA_VISIBLE_DEVICES=$DEV0,$DEV1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) dataloader/distributed/test_distributed_repeating_dataloader.py -k "test_resumable_dataloader_without_shuffling" $COVERAGE
 
 # test_distributed_dataloader
-CUDA_VISIBLE_DEVICES=0,1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) dataloader/distributed/test_distributed_dataloader.py -k "test_resumable_dataloader_without_shuffling"
-CUDA_VISIBLE_DEVICES=0,1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) dataloader/distributed/test_distributed_dataloader.py -k "test_resumable_dataloader_with_shuffling_without_skipping"
-CUDA_VISIBLE_DEVICES=0,1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) dataloader/distributed/test_distributed_dataloader.py -k "test_resumable_dataloader_with_shuffling_and_skipped_batches"
+CUDA_VISIBLE_DEVICES=$DEV0,$DEV1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) dataloader/distributed/test_distributed_dataloader.py -k "test_resumable_dataloader_without_shuffling" $COVERAGE
+CUDA_VISIBLE_DEVICES=$DEV0,$DEV1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) dataloader/distributed/test_distributed_dataloader.py -k "test_resumable_dataloader_with_shuffling_without_skipping" $COVERAGE
+CUDA_VISIBLE_DEVICES=$DEV0,$DEV1 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 2 $(which pytest) dataloader/distributed/test_distributed_dataloader.py -k "test_resumable_dataloader_with_shuffling_and_skipped_batches" $COVERAGE
 
 # test optimizer
-CUDA_VISIBLE_DEVICES=0 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 1 $(which pytest) test_optimizer_factory.py
+CUDA_VISIBLE_DEVICES=$DEV0 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 1 $(which pytest) test_optimizer_factory.py $COVERAGE
+
+# test initialization
+CUDA_VISIBLE_DEVICES=$DEV0 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 1 $(which pytest) test_initialization.py $COVERAGE
 

--- a/tests/run_distributed_tests.sh
+++ b/tests/run_distributed_tests.sh
@@ -1,12 +1,25 @@
 #!/bin/sh
 
+#######################
+### INPUT ARGUMENTS ###
+#######################
+if [ -z "$1" ] || [ -z "$2" ]  # if one of the two input arguments does not exist
+  then
+    echo "Need to specify 2 GPU devices as arguments, e.g. bash run_distributed_tests.sh 0 1"
+    exit
+fi
+if [[ $1 =~ [^0-7] ]] || [[ $2 =~ [^0-7] ]]  # if one of the two input arguments is not an integer 0-7
+    then
+        echo "Need to specify integers 0-7 as arguments, e.g. bash run_distributed_tests.sh 0 1"
+        exit
+fi
+
 #################
 ### VARIABLES ###
 #################
-DEV0=3
-DEV1=4
+DEV0=$1 
+DEV1=$2
 COVERAGE=--no-cov
-
 
 #############
 ### TESTS ###
@@ -29,7 +42,3 @@ CUDA_VISIBLE_DEVICES=$DEV0,$DEV1 torchrun --rdzv-endpoint localhost:29502 --nnod
 
 # test optimizer
 CUDA_VISIBLE_DEVICES=$DEV0 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 1 $(which pytest) test_optimizer_factory.py $COVERAGE
-
-# test initialization
-CUDA_VISIBLE_DEVICES=$DEV0 torchrun --rdzv-endpoint localhost:29502 --nnodes 1 --nproc_per_node 1 $(which pytest) test_initialization.py $COVERAGE
-

--- a/tests/test_optimizer_factory.py
+++ b/tests/test_optimizer_factory.py
@@ -72,7 +72,7 @@ def _load_coca() -> FSDP:
 
 # number of parameters for each optimizer group
 GPT2_LINEAR = 66130944
-GPT2_EMBEDDING = 768 * (50304 + 2048)  # n_embd * (vocab_size + block_size)
+GPT2_EMBEDDING = 768 * (50304 + 2048 - 1)  # n_embd * (vocab_size + block_size - 1)
 GPT2_LAYERNORM = 768 * 50  # n_embd * num_layer_norms
 COCA_ALL = 184502784
 
@@ -117,5 +117,9 @@ def test_get_optimizer_groups(
                 p.numel() for group in optimizer_groups for p in group["params"] if group["weight_decay"] == 0
             )
 
-            assert test_num_decayed_parameters == num_decayed_parameters
-            assert test_num_nondecayed_parameters == num_nondecayed_parameters
+            assert (
+                test_num_decayed_parameters == num_decayed_parameters
+            ), f"#(decayed parameters) = {test_num_decayed_parameters} should be {num_decayed_parameters}"
+            assert (
+                test_num_nondecayed_parameters == num_nondecayed_parameters
+            ), f"#(non-decayed parameters) = {test_num_nondecayed_parameters} should be {num_nondecayed_parameters}"

--- a/tests/test_yaml_configs/gpt2_config_optimizer.yaml
+++ b/tests/test_yaml_configs/gpt2_config_optimizer.yaml
@@ -16,6 +16,7 @@ model:
     bias: true # True: bias in Linears and LayerNorms, like GPT-2. False: a bit better and faster
     attention_config:
       qkv_transforms: []
+    attention_implementation: manual
     activation_type: gelu
     weight_init:
       mean: 0.0

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -41,7 +41,9 @@ def main(cpu: bool = False, single_gpu: bool = False, multi_gpu: bool = False, d
 
     # run cpu / single-gpu tests
     if cpu or single_gpu:
-        command_unit_tests = f"CUDA_VISIBLE_DEVICES={devices[0] if single_gpu else None} pytest"
+        command_unit_tests = (
+            f"cd {_ROOT_DIR} && CUDA_VISIBLE_DEVICES={devices[0] if single_gpu else None} python -m pytest"
+        )
 
         print("\n=== RUN CPU & SINGLE-GPU TESTS ===" if single_gpu else "\n=== RUN CPU TESTS ===")
         print(command_unit_tests)


### PR DESCRIPTION
This PR
- [x] introduces a new script `tests/tests.py`, which can be used for both unit and end-to-end testing. (https://github.com/Modalities/modalities/pull/155/commits/6101bb9c5ad7475c1f39afd45164a95b9071104e, https://github.com/Modalities/modalities/pull/155/commits/81cacfa63c29218ad8ffbad5a54589c928bd3606, https://github.com/Modalities/modalities/pull/155/commits/74045d832d699ef89fa20ff3dc2e8d610a373445, https://github.com/Modalities/modalities/pull/155/commits/e0d0a42c484d7d227cd333f421c92ddbee54b29d, https://github.com/Modalities/modalities/pull/155/commits/563cf27bd1f5bca5fe83caf25fd8f52b68f44421)

  Examples:
  - `python tests/tests.py`: run CPU tests + single-GPU tests on GPU 0 + multi-GPU tests on GPUs 0/1
  - `python tests/tests.py --devices 4,5`: same as above but using devices 4/5
  - `python tests/tests.py --cpu`: run CPU tests
  - `python tests/tests.py --single-gpu --devices 3`:  run CPU tests + single-GPU tests on GPU 3 
  - `python tests/tests.py --multi-gpu --devices 3,4`: run multi-GPU tests on GPUs 3/4
  
  Note that any GPU device 0-7 can be specified. 
  
- [x] fixes some unit test minor issues (6c4e0f488e68aad2b9b0534291f95a7557392596, 5d2cd148b5376e9cba0a2a3192e66bda90646114)
- [x] fixes all end-to-end tests (all other commits)