### PR TITLE
Make Activation Checkpointing Configurable

### DIFF
--- a/config_files/training/config_example_coca.yaml
+++ b/config_files/training/config_example_coca.yaml
@@ -10,7 +10,7 @@ settings:
     global_evaluation_interval_in_steps: 2
     global_num_training_samples: 12
     global_num_seen_steps: 0
-    do_apply_activation_checkpointing: true
+    activation_checkpointing_modules: []
     gradient_acc_steps: 1
     local_train_micro_batch_size: 3
     sequence_length: 256

--- a/config_files/training/config_example_hf_meditron_7B_instruction.yaml
+++ b/config_files/training/config_example_hf_meditron_7B_instruction.yaml
@@ -8,7 +8,7 @@ settings:
     callback_interval_in_samples: 2048
     global_num_training_samples: 2048
     global_num_seen_samples: 0
-    do_apply_activation_checkpointing: true
+    activation_checkpointing_modules: []
     gradient_acc_steps: 1
     local_train_micro_batch_size: 1
     sequence_length: 4096

--- a/config_files/training/config_gpt2_small_overfitting_de.yaml
+++ b/config_files/training/config_gpt2_small_overfitting_de.yaml
@@ -9,7 +9,7 @@ settings:
     global_checkpointing_interval_in_steps: 128 
     global_evaluation_interval_in_steps: 64
     global_num_seen_steps: 0
-    do_apply_activation_checkpointing: false
+    activation_checkpointing_modules: []
     gradient_acc_steps: 1
     local_train_micro_batch_size: 16
     sequence_length: 2048

--- a/config_files/training/config_gpt2_small_overfitting_de_abs_pos_emb.yaml
+++ b/config_files/training/config_gpt2_small_overfitting_de_abs_pos_emb.yaml
@@ -9,7 +9,7 @@ settings:
     global_checkpointing_interval_in_steps: 128 
     global_evaluation_interval_in_steps: 64
     global_num_seen_steps: 0
-    do_apply_activation_checkpointing: false
+    activation_checkpointing_modules: []
     gradient_acc_steps: 1
     local_train_micro_batch_size: 16
     sequence_length: 2048

--- a/config_files/training/config_gpt2_small_redpajama_DE_1048576.yaml
+++ b/config_files/training/config_gpt2_small_redpajama_DE_1048576.yaml
@@ -9,7 +9,7 @@ settings:
     global_checkpointing_interval_in_steps: 8192
     global_evaluation_interval_in_steps: 1024
     global_num_seen_steps: 0
-    do_apply_activation_checkpointing: false
+    activation_checkpointing_modules: []
     gradient_acc_steps: 1
     local_train_micro_batch_size: 16
     sequence_length: 2048

--- a/config_files/training/config_lorem_ipsum.yaml
+++ b/config_files/training/config_lorem_ipsum.yaml
@@ -10,6 +10,7 @@ settings:
     global_evaluation_interval_in_steps: 2
     global_num_seen_steps: 0
     do_apply_activation_checkpointing: true
+    activation_checkpointing_modules: [GPT2Block]
     gradient_acc_steps: 1
     local_train_micro_batch_size: 1
     sequence_length: 256

--- a/config_files/training/config_lorem_ipsum.yaml
+++ b/config_files/training/config_lorem_ipsum.yaml
@@ -9,7 +9,6 @@ settings:
     global_checkpointing_interval_in_steps: 3
     global_evaluation_interval_in_steps: 2
     global_num_seen_steps: 0
-    do_apply_activation_checkpointing: true
     activation_checkpointing_modules: [GPT2Block]
     gradient_acc_steps: 1
     local_train_micro_batch_size: 1

--- a/config_files/training/config_mem_map_mamba.yaml
+++ b/config_files/training/config_mem_map_mamba.yaml
@@ -8,7 +8,7 @@ settings:
     callback_interval_in_samples: 32768
     global_num_training_samples: 2048
     global_num_seen_samples: 0
-    do_apply_activation_checkpointing: false
+    activation_checkpointing_modules: []
     gradient_acc_steps: 1
     local_train_micro_batch_size: 16
     sequence_length: 4096

--- a/config_files/training/config_mem_map_mamba_overfitting.yaml
+++ b/config_files/training/config_mem_map_mamba_overfitting.yaml
@@ -9,7 +9,7 @@ settings:
     global_checkpointing_interval_in_steps: 1000 
     global_evaluation_interval_in_steps: 64
     global_num_seen_steps: 0
-    do_apply_activation_checkpointing: false
+    activation_checkpointing_modules: []
     gradient_acc_steps: 1
     local_train_micro_batch_size: 4
     sequence_length: 2048

--- a/config_files/training/config_mem_map_mamba_small_scale.yaml
+++ b/config_files/training/config_mem_map_mamba_small_scale.yaml
@@ -9,7 +9,7 @@ settings:
     global_checkpointing_interval_in_steps: 1000
     global_evaluation_interval_in_steps: 64
     global_num_seen_steps: 0
-    do_apply_activation_checkpointing: false
+    activation_checkpointing_modules: []
     gradient_acc_steps: 1
     local_train_micro_batch_size: 4
     sequence_length: 0 # TODO: Is sequence_length used in training?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "datasets",
     "protobuf",
     "SentencePiece",
-    "accelerate",
     "rich",
     "omegaconf",
     "pydantic",

--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -221,7 +221,7 @@ class Main:
         wrapped_model = components.wrapped_model
         logging.info(f"Training model with {compute_number_of_trainable_parameters(wrapped_model)} parameters.")
 
-        if components.settings.training.activation_checkpointing_modules:
+        if len(components.settings.training.activation_checkpointing_modules) > 0:
             apply_activation_checkpointing_inplace(
                 model=wrapped_model, 
                 activation_checkpointing_modules=components.settings.training.activation_checkpointing_modules,

--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -221,8 +221,11 @@ class Main:
         wrapped_model = components.wrapped_model
         logging.info(f"Training model with {compute_number_of_trainable_parameters(wrapped_model)} parameters.")
 
-        if components.settings.training.do_apply_activation_checkpointing:
-            apply_activation_checkpointing_inplace(wrapped_model)
+        if components.settings.training.activation_checkpointing_modules:
+            apply_activation_checkpointing_inplace(
+                model=wrapped_model, 
+                activation_checkpointing_modules=components.settings.training.activation_checkpointing_modules,
+                )
 
         gym.run(
             train_data_loader=components.train_dataloader,

--- a/src/modalities/activation_checkpointing.py
+++ b/src/modalities/activation_checkpointing.py
@@ -1,4 +1,6 @@
 from functools import partial
+from typing import List
+from accelerate import FullyShardedDataParallelPlugin
 
 import torch
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
@@ -8,14 +10,16 @@ from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
 )
 from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataParallel as FSDP
 
-from modalities.models.gpt2.gpt2_model import GPT2Block
+
+import torch
+from typing import List
+
+def is_module_to_apply_activation_checkpointing(submodule: torch.nn.Module, activation_checkpointing_modules: List[type]) -> bool:
+    return isinstance(submodule, tuple(activation_checkpointing_modules))
 
 
-def is_module_to_apply_activation_checkpointing(submodule: torch.nn.Module) -> bool:
-    return isinstance(submodule, GPT2Block)
-
-
-def apply_activation_checkpointing_inplace(model: torch.nn.Module):
+def apply_activation_checkpointing_inplace(model: torch.nn.Module, activation_checkpointing_modules: List[str]):
+    activation_checkpointing_modules = [FullyShardedDataParallelPlugin.get_module_class_from_name(model, m) for m in activation_checkpointing_modules]
     assert isinstance(model, FSDP), "activation checkpointing can only be applied to FSDP wrapped models!"
     non_reentrant_wrapper = partial(checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT, debug=False)
 

--- a/src/modalities/activation_checkpointing.py
+++ b/src/modalities/activation_checkpointing.py
@@ -21,7 +21,8 @@ def is_module_to_apply_activation_checkpointing(submodule: torch.nn.Module, acti
 
 def apply_activation_checkpointing_inplace(model: torch.nn.Module, activation_checkpointing_modules: List[str]):
     activation_checkpointing_modules = [get_module_class_from_name(model, m) for m in activation_checkpointing_modules]
-    assert isinstance(model, FSDP), "activation checkpointing can only be applied to FSDP wrapped models!"
+    if not isinstance(model, FSDP)
+        raise ValueError("activation checkpointing can only be applied to FSDP wrapped models!")
     non_reentrant_wrapper = partial(checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT, debug=False)
 
     apply_activation_checkpointing(

--- a/src/modalities/activation_checkpointing.py
+++ b/src/modalities/activation_checkpointing.py
@@ -1,6 +1,5 @@
 from functools import partial
 from typing import List
-from accelerate import FullyShardedDataParallelPlugin
 
 import torch
 from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
@@ -14,12 +13,14 @@ from torch.distributed.fsdp.fully_sharded_data_parallel import FullyShardedDataP
 import torch
 from typing import List
 
+from modalities.util import get_module_class_from_name
+
 def is_module_to_apply_activation_checkpointing(submodule: torch.nn.Module, activation_checkpointing_modules: List[type]) -> bool:
     return isinstance(submodule, tuple(activation_checkpointing_modules))
 
 
 def apply_activation_checkpointing_inplace(model: torch.nn.Module, activation_checkpointing_modules: List[str]):
-    activation_checkpointing_modules = [FullyShardedDataParallelPlugin.get_module_class_from_name(model, m) for m in activation_checkpointing_modules]
+    activation_checkpointing_modules = [get_module_class_from_name(model, m) for m in activation_checkpointing_modules]
     assert isinstance(model, FSDP), "activation checkpointing can only be applied to FSDP wrapped models!"
     non_reentrant_wrapper = partial(checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT, debug=False)
 

--- a/src/modalities/activation_checkpointing.py
+++ b/src/modalities/activation_checkpointing.py
@@ -20,7 +20,7 @@ def is_module_to_apply_activation_checkpointing(submodule: torch.nn.Module, acti
 
 
 def apply_activation_checkpointing_inplace(model: torch.nn.Module, activation_checkpointing_modules: List[str]):
-    activation_checkpointing_modules = [get_module_class_from_name(model, m) for m in activation_checkpointing_modules]
+    activation_checkpointing_module_types = [get_module_class_from_name(model, m) for m in activation_checkpointing_modules]
     if not isinstance(model, FSDP)
         raise ValueError("activation checkpointing can only be applied to FSDP wrapped models!")
     non_reentrant_wrapper = partial(checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT, debug=False)

--- a/src/modalities/activation_checkpointing.py
+++ b/src/modalities/activation_checkpointing.py
@@ -21,10 +21,10 @@ def is_module_to_apply_activation_checkpointing(submodule: torch.nn.Module, acti
 
 def apply_activation_checkpointing_inplace(model: torch.nn.Module, activation_checkpointing_modules: List[str]):
     activation_checkpointing_module_types = [get_module_class_from_name(model, m) for m in activation_checkpointing_modules]
-    if not isinstance(model, FSDP)
+    if not isinstance(model, FSDP):
         raise ValueError("activation checkpointing can only be applied to FSDP wrapped models!")
     non_reentrant_wrapper = partial(checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT, debug=False)
 
     apply_activation_checkpointing(
-        model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=lambda submodule: is_module_to_apply_activation_checkpointing(submodule, activation_checkpointing_modules_types)
+        model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=lambda submodule: is_module_to_apply_activation_checkpointing(submodule, activation_checkpointing_module_types)
     )

--- a/src/modalities/activation_checkpointing.py
+++ b/src/modalities/activation_checkpointing.py
@@ -26,5 +26,5 @@ def apply_activation_checkpointing_inplace(model: torch.nn.Module, activation_ch
     non_reentrant_wrapper = partial(checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT, debug=False)
 
     apply_activation_checkpointing(
-        model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=lambda submodule: is_module_to_apply_activation_checkpointing(submodule, activation_checkpointing_modules)
+        model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=lambda submodule: is_module_to_apply_activation_checkpointing(submodule, activation_checkpointing_modules_types)
     )

--- a/src/modalities/activation_checkpointing.py
+++ b/src/modalities/activation_checkpointing.py
@@ -25,5 +25,5 @@ def apply_activation_checkpointing_inplace(model: torch.nn.Module, activation_ch
     non_reentrant_wrapper = partial(checkpoint_wrapper, checkpoint_impl=CheckpointImpl.NO_REENTRANT, debug=False)
 
     apply_activation_checkpointing(
-        model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=is_module_to_apply_activation_checkpointing
+        model, checkpoint_wrapper_fn=non_reentrant_wrapper, check_fn=lambda submodule: is_module_to_apply_activation_checkpointing(submodule, activation_checkpointing_modules)
     )

--- a/src/modalities/config/instantiation_models.py
+++ b/src/modalities/config/instantiation_models.py
@@ -32,7 +32,7 @@ class TrainingComponentsInstantiationModel(BaseModel):
             global_training_log_interval_in_steps: Annotated[int, Field(strict=True, ge=1)]
             global_checkpointing_interval_in_steps: Annotated[int, Field(strict=True, ge=1)]
             global_evaluation_interval_in_steps: Annotated[int, Field(strict=True, ge=1)]
-            do_apply_activation_checkpointing: bool
+            activation_checkpointing_modules: Optional[List[str]]
             gradient_acc_steps: Annotated[int, Field(strict=True, ge=1)]
             local_train_micro_batch_size: Annotated[int, Field(strict=True, ge=1)]
             sequence_length: Annotated[int, Field(strict=True, ge=1)]

--- a/src/modalities/config/instantiation_models.py
+++ b/src/modalities/config/instantiation_models.py
@@ -32,7 +32,7 @@ class TrainingComponentsInstantiationModel(BaseModel):
             global_training_log_interval_in_steps: Annotated[int, Field(strict=True, ge=1)]
             global_checkpointing_interval_in_steps: Annotated[int, Field(strict=True, ge=1)]
             global_evaluation_interval_in_steps: Annotated[int, Field(strict=True, ge=1)]
-            activation_checkpointing_modules: Optional[List[str]]
+            activation_checkpointing_modules: Optional[List[str]] = Field(default_factory=list)
             gradient_acc_steps: Annotated[int, Field(strict=True, ge=1)]
             local_train_micro_batch_size: Annotated[int, Field(strict=True, ge=1)]
             sequence_length: Annotated[int, Field(strict=True, ge=1)]

--- a/src/modalities/running_env/fsdp/fsdp_auto_wrapper.py
+++ b/src/modalities/running_env/fsdp/fsdp_auto_wrapper.py
@@ -4,10 +4,10 @@ from abc import ABC, abstractmethod
 from typing import Callable, List
 
 import torch.nn as nn
-from accelerate import FullyShardedDataParallelPlugin
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 
 from modalities.config.lookup_enum import LookupEnum
+from modalities.util import get_module_class_from_name
 
 
 class FSDPAutoWrapFactoryIF(ABC):
@@ -28,12 +28,8 @@ class FSDPTransformerAutoWrapPolicyFactory(FSDPAutoWrapFactoryIF):
         for cls_block_name in block_names:
             # TODO FullyShardedDataParallelPlugin from Accelerate uses string matching to find the correct
             # block class. In the long-term we should implmement this ourselves in a robuster fashion.
-            try:
-                block_type = FullyShardedDataParallelPlugin.get_module_class_from_name(model, cls_block_name)
-            except AttributeError:
-                from accelerate.utils.dataclasses import get_module_class_from_name
+            block_type = get_module_class_from_name(model, cls_block_name)
 
-                block_type = get_module_class_from_name(model, cls_block_name)
             if block_type is None:
                 raise ValueError(f"Could not find block with name {cls_block_name} in model")
             fsdp_block_types.append(block_type)

--- a/src/modalities/util.py
+++ b/src/modalities/util.py
@@ -136,3 +136,23 @@ class Aggregator(Generic[T]):
             post_processing_fun=postprocessing_fun,  # lambda t: t[0] / t[1],
         )
         return value
+
+def get_module_class_from_name(module, name):
+    """ From Accelerate source code 
+    (https://github.com/huggingface/accelerate/blob/1f7a79b428749f45187ec69485f2c966fe21926e/src/accelerate/utils/dataclasses.py#L1902)
+    Gets a class from a module by its name.
+
+    Args:
+        module (`torch.nn.Module`): The module to get the class from.
+        name (`str`): The name of the class.
+    """
+    modules_children = list(module.children())
+    if module.__class__.__name__ == name:
+        return module.__class__
+    elif len(modules_children) == 0:
+        return
+    else:
+        for child_module in modules_children:
+            module_class = get_module_class_from_name(child_module, name)
+            if module_class is not None:
+                return module_class

--- a/src/modalities/util.py
+++ b/src/modalities/util.py
@@ -137,7 +137,7 @@ class Aggregator(Generic[T]):
         )
         return value
 
-def get_module_class_from_name(module, name):
+def get_module_class_from_name(module: torch.nn.Module, name:str) -> Type[torch.nn.Module] | None:
     """ From Accelerate source code 
     (https://github.com/huggingface/accelerate/blob/1f7a79b428749f45187ec69485f2c966fe21926e/src/accelerate/utils/dataclasses.py#L1902)
     Gets a class from a module by its name.

--- a/tests/models/coca/coca_config.yaml
+++ b/tests/models/coca/coca_config.yaml
@@ -33,7 +33,7 @@ text_decoder_config:
   n_embd: 768
   dropout: 0.0
   bias: true
-  activation: fused_swiglu
+  activation: swiglu
   epsilon: 1e-5
 n_pool_head: 8
 n_vision_queries: 256


### PR DESCRIPTION
This PR addresses the issue described in [Issue #32](https://github.com/Modalities/modalities/issues/32) by removing the hard-coded dependency for applying activation checkpointing specifically to `GPT2Block`. Instead, activation checkpointing is now made configurable through the configuration file, allowing greater flexibility and adaptability for different models.


**General changes:**
* Enhancement: Allow the definition of modules to be checkpointed within the configuration file


**Breaking changes:** 
* Enhacement: make modules to be checkpointed configurable.
This requires replacing the boolean entry `do_apply_activation_checkpointing` in the configuration file with the list `activation_checkpointing_modules` (see 4a2a049e893acdd49c2dd7801b74a20af0db1e38), which specifies all the submodules to which activation checkpointing should be applied.

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue / enhancement in isolation
- [x] I have merged main into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [x] I have run a sample config for model training
- [x] I have fixed all failing tests (`python tests/tests.py`)