### PR TITLE
Support and test python versions 3.10 and 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "modalities"
 version = "0.1.0"
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.10,<3.12"
 description = "Modalities, a python framework for distributed and reproducible foundation model training."
 dependencies = [
     "numpy<2.0",


### PR DESCRIPTION
# What does this PR do?

This PR fixes #173 by 
* restricting the supported python versions to 3.10 and 3.11
* extending unit testing to 3.11.

## General Changes
* none apart from the above

## Breaking Changes
* none

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [ ] I have checked that all tests run through (`python tests/tests.py`)