### PR TITLE
Fix pydantic warnings about model_ namespace

### DIFF
--- a/src/modalities/config/config.py
+++ b/src/modalities/config/config.py
@@ -5,7 +5,7 @@ from typing import Annotated, Callable, Dict, List, Literal, Optional, Tuple
 
 import torch
 from omegaconf import OmegaConf
-from pydantic import BaseModel, Field, FilePath, PositiveInt, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, FilePath, PositiveInt, field_validator, model_validator
 from torch.distributed.fsdp import ShardingStrategy
 from transformers import GPT2TokenizerFast
 from transformers.models.llama.tokenization_llama_fast import LlamaTokenizerFast
@@ -233,6 +233,10 @@ class FSDPWrappedModelConfig(BaseModel):
 class WeightInitializedModelConfig(BaseModel):
     model: PydanticPytorchModuleType
     model_initializer: PydanticModelInitializationIFType
+
+    # avoid warning about protected namespace 'model_', see
+    # https://docs.pydantic.dev/2.7/api/config/#pydantic.config.ConfigDict.protected_namespaces
+    model_config = ConfigDict(protected_namespaces=())
 
 
 class PreTrainedHFTokenizerConfig(BaseModel):

--- a/src/modalities/config/instantiation_models.py
+++ b/src/modalities/config/instantiation_models.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import Annotated, Dict, List, Optional
 
-from pydantic import BaseModel, Field, FilePath, field_validator
+from pydantic import BaseModel, ConfigDict, Field, FilePath, field_validator
 
 from modalities.config.pydanctic_if_types import (
     PydanticCheckpointSavingIFType,
@@ -81,6 +81,10 @@ class TextGenerationInstantiationModel(BaseModel):
         sequence_length: int
         device: PydanticPytorchDeviceType
         referencing_keys: Dict[str, str]
+
+        # avoid warning about protected namespace 'model_', see
+        # https://docs.pydantic.dev/2.7/api/config/#pydantic.config.ConfigDict.protected_namespaces
+        model_config = ConfigDict(protected_namespaces=())
 
         @field_validator("device", mode="before")
         def parse_device(cls, device) -> PydanticPytorchDeviceType:

--- a/src/modalities/nn/model_initialization/composed_initialization.py
+++ b/src/modalities/nn/model_initialization/composed_initialization.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 import torch.nn as nn
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from typing_extensions import Annotated
 
 from modalities.config.pydanctic_if_types import PydanticModelInitializationIFType
@@ -17,6 +17,10 @@ from modalities.nn.model_initialization.parameter_name_filters import (
 class ModelInitializerWrapperConfig(BaseModel):
     model_initializers: List[PydanticModelInitializationIFType]
 
+    # avoid warning about protected namespace 'model_', see
+    # https://docs.pydantic.dev/2.7/api/config/#pydantic.config.ConfigDict.protected_namespaces
+    model_config = ConfigDict(protected_namespaces=())
+
 
 class ComposedModelInitializationConfig(BaseModel):
     model_type: SupportWeightInitModels
@@ -26,6 +30,10 @@ class ComposedModelInitializationConfig(BaseModel):
     std: Annotated[float, Field(strict=True, ge=0.0)] | str  # can be float or "auto"
     hidden_dim: Optional[Annotated[int, Field(strict=True, gt=0)]] = None
     num_layers: Optional[Annotated[int, Field(strict=True, gt=0)]] = None
+
+    # avoid warning about protected namespace 'model_', see
+    # https://docs.pydantic.dev/2.7/api/config/#pydantic.config.ConfigDict.protected_namespaces
+    model_config = ConfigDict(protected_namespaces=())
 
     @model_validator(mode="after")
     def _check_values(self):


### PR DESCRIPTION
# What does this PR do?

This PR fixes pydantic warnings like `UserWarning: Field "model_initializer" has conflict with protected namespace "model_"` (see #108) in the same way as #109. This should probably be considered a quick fix rather than a permanent solution (see #200).

## General Changes
none except for the above

## Breaking Changes
none 

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [ ] I have checked that all tests run through (`python tests/tests.py`)