### PR TITLE
feat: log model initialization & training start/end

### DIFF
--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -278,7 +278,6 @@ class Main:
             evaluation_interval_in_steps=components.settings.training.evaluation_interval_in_steps,
             training_log_interval_in_steps=components.settings.training.training_log_interval_in_steps,
         )
-        print_rank_0(f"Training done at {datetime.now()}.")
 
     def get_logging_publishers(
         self,

--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import shutil
+from datetime import datetime
 from pathlib import Path
 from typing import Tuple, Type
 
@@ -34,7 +35,7 @@ from modalities.registry.components import COMPONENTS
 from modalities.registry.registry import Registry
 from modalities.running_env.cuda_env import CudaEnv
 from modalities.trainer import Trainer
-from modalities.util import get_total_number_of_trainable_parameters
+from modalities.util import get_total_number_of_trainable_parameters, print_rank_0
 
 
 @click.group()
@@ -211,6 +212,7 @@ class Main:
         return components
 
     def run(self, components: TrainingComponentsInstantiationModel):
+        print_rank_0(f"Initialize Model at {datetime.now()}.")
         # save the config file to the checkpointing path
         if components.settings.cuda_env.global_rank == 0:
             experiment_path = components.settings.paths.checkpointing_path / components.settings.experiment_id
@@ -263,6 +265,7 @@ class Main:
                 model=wrapped_model,
                 activation_checkpointing_modules=components.settings.training.activation_checkpointing_modules,
             )
+        print_rank_0(f"Model initialized at {datetime.now()}.")
 
         gym.run(
             train_data_loader=components.train_dataloader,
@@ -275,7 +278,7 @@ class Main:
             evaluation_interval_in_steps=components.settings.training.evaluation_interval_in_steps,
             training_log_interval_in_steps=components.settings.training.training_log_interval_in_steps,
         )
-        print("done")
+        print_rank_0(f"Training done at {datetime.now()}.")
 
     def get_logging_publishers(
         self,

--- a/src/modalities/gym.py
+++ b/src/modalities/gym.py
@@ -68,6 +68,7 @@ class Gym:
             checkpointing_callback=checkpointing_callback,
             training_log_interval_in_steps=training_log_interval_in_steps,
         )
+        print_rank_0(f"Training done at {datetime.now()}.")
 
     def _run_checkpointing(
         self,

--- a/src/modalities/gym.py
+++ b/src/modalities/gym.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from functools import partial
 from typing import Callable, List
 
@@ -10,6 +11,7 @@ from modalities.dataloader.dataloader import LLMDataLoader
 from modalities.evaluator import Evaluator
 from modalities.loss_functions import Loss
 from modalities.trainer import Trainer
+from modalities.util import print_rank_0
 
 
 class Gym:
@@ -55,6 +57,7 @@ class Gym:
             checkpointing_interval_in_steps=checkpointing_interval_in_steps,
         )
 
+        print_rank_0(f"Start model training at {datetime.now()}.")
         self.trainer.train(
             model=model,
             train_loader=train_data_loader,

--- a/src/modalities/util.py
+++ b/src/modalities/util.py
@@ -18,7 +18,7 @@ from modalities.running_env.fsdp.reducer import Reducer
 
 
 def print_rank_0(message: str):
-    """If distributed is initialized, print only on rank 0."""
+    """If torch.distributed is initialized, print only on rank 0."""
     if torch.distributed.is_initialized():
         if torch.distributed.get_rank() == 0:
             print(message, flush=True)


### PR DESCRIPTION
# What does this PR do?

This PR introduces logging for critical stages in the training pipeline, specifically during model initialization and the start and end of model training. These enhancements aim to improve the transparency, debuggability, and traceability of the model lifecycle events, facilitating easier monitoring and troubleshooting.

## General Changes
* Log time and date for specific lifecycle events.

## Breaking Changes
* None.

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [x] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)