### PR TITLE
Fix CPU Tests with Github Actions for torch>=2.4

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -213,9 +213,15 @@ def set_env_cpu(monkeypatch):
 
     # TODO: discuss with Mehdi and Max and explain the side effects here.
     torch_distributed_cleanup()
+
     # setting CUDA_VISIBLE_DEVICES to "" creates a cache entry, which prevents resetting this CPU-only setup.
     # therefore after finish using this fixture, we need to clear this cache
-    torch.cuda.device_count.cache_clear()
+    if torch.__version__ < "2.4":
+        # see https://pytorch.org/docs/2.3/_modules/torch/cuda.html#device_count
+        torch.cuda.device_count.cache_clear()
+    else:
+        # see https://pytorch.org/docs/2.4/_modules/torch/cuda.html#device_count
+        torch.cuda._cached_device_count = None
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
# What does this PR do?

This PR fixes #203.

The problem was caused by a breaking change in torch 2.4 regarding the way caching of `device_count` works, compare https://pytorch.org/docs/2.3/_modules/torch/cuda.html#device_count and https://pytorch.org/docs/2.4/_modules/torch/cuda.html#device_count

## General Changes
none except for the above

## Breaking Changes
none

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)