### PR TITLE
Fix linting & improve test_utils

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,7 +46,7 @@ def test_get_total_number_of_trainable_parameters():
     model = torch.nn.Sequential(torch.nn.Linear(10, 5), torch.nn.ReLU(), torch.nn.Linear(5, 2))
 
     # Calculate the expected number of trainable parameters
-    expected_params = 10*5 + 5 + 5*2 + 2  # weights_1 + bias_1 + weights_2 + bias_2 = 67
+    expected_params = 10 * 5 + 5 + 5 * 2 + 2  # weights_1 + bias_1 + weights_2 + bias_2 = 67
     world_size = 8
     num_gpus_per_node = 4
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,7 +35,7 @@ def test_get_local_number_of_trainable_parameters():
     model = torch.nn.Sequential(torch.nn.Linear(10, 5), torch.nn.ReLU(), torch.nn.Linear(5, 2))
 
     # Calculate the expected number of trainable parameters
-    expected_params = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    expected_params = 10 * 5 + 5 + 5 * 2 + 2  # weights_1 + bias_1 + weights_2 + bias_2 = 67
 
     # Call the function and check the result
     assert get_local_number_of_trainable_parameters(model) == expected_params


### PR DESCRIPTION
# What does this PR do?

This PR is a follow-up to #216. It
* fixes linting in `test_utils.py`
* replaces the automated parameter counting by manual parameter counting in `test_get_local_number_of_trainable_parameters`. Automated parameter counting seems a bit meaningless since it literally uses the same line of code as the tested function.

## General Changes
none except for the above

## Breaking Changes
none

## Checklist before submitting final PR
- [ ] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)