### PR TITLE
chore: remove link to docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 
 ## Getting Started
 For training and evaluation a model, feel free to checkout [this](https://github.com/Modalities/modalities/blob/main/examples/getting_started/README.md) getting started tutorial, in which we train a small, 60M-parameter GPT model on a tiny subset of the Redpajama V2 dataset. 
-Also, see our Wiki and API reference documentation: https://modalities.github.io/modalities/
 
 ## Installation
 


### PR DESCRIPTION
# What does this PR do?

This PR removes the docs link in the README

## General Changes
* non

## Breaking Changes
* none

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)