### PR TITLE
fix: import T_co from torch

### DIFF
--- a/src/modalities/dataloader/dataloader.py
+++ b/src/modalities/dataloader/dataloader.py
@@ -1,7 +1,12 @@
 from typing import Iterable, Optional, Union
 
 from torch.utils.data import Dataset, DistributedSampler, Sampler
-from torch.utils.data.dataloader import DataLoader, T_co, _collate_fn_t, _worker_init_fn_t
+from torch.utils.data.dataloader import DataLoader, _collate_fn_t, _worker_init_fn_t
+
+try:  # torch <= 2.4
+    from torch.utils.data.dataloader import T_co
+except ImportError:  # torch >= 2.5
+    from torch.utils.data.dataloader import _T_co as T_co
 
 from modalities.dataloader.samplers import ResumableBatchSampler
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes the [failing unit tests](https://github.com/Modalities/modalities/actions/runs/11580918382/job/32240501884) in the main branch.

The problem was caused by the import of a variable that changed its name from `T_co` in torch 2.4 (see [here](https://pytorch.org/docs/2.4/_modules/torch/utils/data/dataloader.html#DataLoader)) to `_T_co` in torch 2.5 (see [here](https://pytorch.org/docs/2.5/_modules/torch/utils/data/dataloader.html#DataLoader)).

## General Changes
* ..

## Breaking Changes
* .. 

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)