### PR TITLE
fix: clone TrainingProgress when saving list of saved checkpoints

### DIFF
--- a/src/modalities/checkpointing/checkpoint_saving_strategies.py
+++ b/src/modalities/checkpointing/checkpoint_saving_strategies.py
@@ -1,3 +1,4 @@
+import dataclasses
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional
 
@@ -71,7 +72,7 @@ class SaveKMostRecentCheckpointsStrategy(CheckpointSavingStrategyIF):
         save_current = True
 
         if self.k > 0:
-            self.saved_step_checkpoints = [training_progress] + self.saved_step_checkpoints
+            self.saved_step_checkpoints = [dataclasses.replace(training_progress)] + self.saved_step_checkpoints
             if len(self.saved_step_checkpoints) > self.k:
                 # Delete oldest checkpoint
                 checkpoints_to_delete = [self.saved_step_checkpoints[-1]]
@@ -79,7 +80,7 @@ class SaveKMostRecentCheckpointsStrategy(CheckpointSavingStrategyIF):
         elif self.k == 0:
             save_current = False
         elif self.k == -1:
-            self.saved_step_checkpoints = [training_progress] + self.saved_step_checkpoints
+            self.saved_step_checkpoints = [dataclasses.replace(training_progress)] + self.saved_step_checkpoints
 
         return CheckpointingInstruction(save_current=save_current, checkpoints_to_delete=checkpoints_to_delete)
 

--- a/tests/checkpointing/test_checkpoint_strategies.py
+++ b/tests/checkpointing/test_checkpoint_strategies.py
@@ -14,7 +14,7 @@ from modalities.training.training_progress import TrainingProgress
         # k value is 0. No deletion of checkpoints.
         (0, [], [], False),
         # k value is 2, but there are currently only one checkpoint. Hence, no deletion.
-        (2, [1], [], True),
+        (2, [TrainingProgress(1, 1, 20, 20)], [], True),
         # k value is -1, therefore we want to keep all checkpoints without any deletion
         (
             -1,
@@ -27,8 +27,12 @@ from modalities.training.training_progress import TrainingProgress
 def test_checkpoint_strategy_k(
     k: int, saved_instances: List[TrainingProgress], checkpoints_to_delete: List[int], save_current: bool
 ) -> None:
+    num_seen_steps_current_run = 10
     training_progress = TrainingProgress(
-        num_seen_steps_current_run=10, num_seen_tokens_current_run=10, num_target_steps=20, num_target_tokens=40
+        num_seen_steps_current_run=num_seen_steps_current_run,
+        num_seen_tokens_current_run=10,
+        num_target_steps=20,
+        num_target_tokens=40,
     )
     checkpoint_strategy = SaveKMostRecentCheckpointsStrategy(k=k)
     checkpoint_strategy.saved_step_checkpoints = saved_instances
@@ -36,3 +40,8 @@ def test_checkpoint_strategy_k(
 
     assert checkpoint_instruction.checkpoints_to_delete == checkpoints_to_delete
     assert checkpoint_instruction.save_current == save_current
+
+    # make sure that modifying the training progress externally does not affect saved_step_checkpoints
+    if k != 0 and save_current:
+        training_progress.num_seen_steps_current_run = 100
+        assert checkpoint_strategy.saved_step_checkpoints[0].num_seen_steps_current_run == num_seen_steps_current_run


### PR DESCRIPTION
# What does this PR do?

The list of `saved_step_checkpoints` contains TrainingProgress objects which are *references* to the TrainingProgress objects, which are updated during training. So all elements in the list will be the same, and will correspond to the current progress. Thus, in cases where `k > 0`, only the first k checkpoints are saved, and all remaining checkpoints are created and immediately deleted (since the `checkpoints_to_delete` is the same as the most recently saved one).  

Solution: clone TrainingProgress object when saving the list of saved checkpoints.

## General Changes
* fixed as above
* added an assert in the test to check for this case

## Breaking Changes
none

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`) ([here](https://github.com/Modalities/modalities/actions/runs/11820173760))
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)