### PR TITLE
Bugfix: the number of bytes per token were wrongly calculated

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -119,3 +119,12 @@ We can also now configure the encoding used for reading the documents. If encodi
 
 **Breaking Changes**
 * None
+
+
+## PR #280 Bugfix: the number of bytes per token were wrongly calculated
+
+This PR fixes the bytes per token calculation.
+Generally, we estimate how many bytes are needed to encode the full range of the vocabulary. 
+E.g., for a vocab size > 65536, we need 3 bytes for each token in the pbin file. 
+
+The calculation was wrong but coincidentally correct for the GPT2 tokenizer. 

--- a/src/modalities/dataloader/create_packed_data.py
+++ b/src/modalities/dataloader/create_packed_data.py
@@ -3,6 +3,7 @@ import math
 import multiprocessing
 import os
 import pickle
+import traceback
 import warnings
 from io import BufferedWriter
 from pathlib import Path
@@ -84,7 +85,7 @@ class PackedDataGenerator:
         Returns:
             int: The number of bytes required to represent the integer.
         """
-        return math.ceil(math.log(math.log2(int_to_get_repr), 8))
+        return math.ceil(math.log2(int_to_get_repr) / 8)
 
     def _encoded_token_to_bytes(self, encoded_token: int) -> bytes:
         """
@@ -292,6 +293,7 @@ class PackedDataGenerator:
                     f"Could not process line of number {line_id} within process {process_id}. "
                     f"Raised the following error: {exception=}"
                 )
+                traceback.print_exc()
 
     def _update_data_length_in_pre_allocated_header(self, dst_path: Path, index_list: list[tuple[int, int]]):
         # Update the length of the data section in the pre-allocated header of the destination file.

--- a/tests/dataloader/test_packed_dataset.py
+++ b/tests/dataloader/test_packed_dataset.py
@@ -259,3 +259,12 @@ def test_continuously_packed_index(token_size_in_bytes: int, block_size: int, to
     )
 
     assert np.all(result_slow == result_vectorized)
+
+
+@pytest.mark.parametrize(
+    "vocab_size, expected_num_bytes",
+    [(254, 1), (255, 1), (256, 1), (257, 2), (65534, 2), (65535, 2), (65536, 2), (65537, 3)],
+)
+def test__get_required_num_of_bytes_to_repr(vocab_size: int, expected_num_bytes: int):
+    num_bytes = PackedDataGenerator._get_required_num_of_bytes_to_repr(int_to_get_repr=vocab_size)
+    assert expected_num_bytes == num_bytes


### PR DESCRIPTION
# What does this PR do?

This PR fixes the bytes per token calculation.
Generally, we estimate how many bytes are needed to encode the full range of the vocabulary. 
E.g., for a vocab size > 65536, we need 3 bytes for each token in the pbin file. 

The calculation was wrong but coincidentally correct for the GPT2 tokenizer. 


## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [ ] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)
- [x] I have updated the internal changelog (`CHANGELOG_DEV.md`)