### PR TITLE
Bugfix: char-based index and byte-based index mismatch

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -128,3 +128,12 @@ Generally, we estimate how many bytes are needed to encode the full range of the
 E.g., for a vocab size > 65536, we need 3 bytes for each token in the pbin file. 
 
 The calculation was wrong but coincidentally correct for the GPT2 tokenizer. 
+
+
+
+## PR #281: The char-based index is not always consistent with the byte-based index.
+
+The first character of the string "ø This is..." is written on disc as two bytes, namely \xc3\xb8, when encoded as utf-8. 
+Therefore, the byte-based index has one more byte/char than the char-based index. 
+
+For consistency, we don't consider any char-based indexes anymore and always refer to byte-based indexes. 

--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -158,8 +158,9 @@ def CMD_entry_point_pack_encoded_data(config_path: FilePath):
     Args:
         config_path (FilePath): Path to the config file describing the tokenization setup.
     """
+    config_dict = load_app_config_dict(config_path)
 
-    pack_encoded_data(config_path=config_path)
+    pack_encoded_data(config_dict=config_dict)
 
 
 @data.command(name="merge_packed_data")

--- a/src/modalities/api.py
+++ b/src/modalities/api.py
@@ -8,7 +8,6 @@ from pydantic import FilePath
 import modalities.inference.inference as inference
 from modalities.checkpointing.checkpoint_conversion import CheckpointConversion
 from modalities.config.component_factory import ComponentFactory
-from modalities.config.config import load_app_config_dict
 from modalities.config.instantiation_models import PackedDatasetComponentsInstantiationModel
 from modalities.dataloader.create_index import IndexGenerator
 from modalities.dataloader.create_packed_data import EmbeddedStreamData, PackedDataGenerator, join_embedded_stream_data
@@ -71,14 +70,14 @@ def convert_pytorch_to_hf_checkpoint(
     return hf_model
 
 
-def pack_encoded_data(config_path: FilePath):
+def pack_encoded_data(config_dict: dict):
     """Packs and encodes an indexed, large jsonl-file.
     (see also `create_index` for more information)
     Returns .pbin-file, which can be inserted into a training process directly
     and does not require its original jsonl-file or the respective index file anymore.
 
     Args:
-        config_path (FilePath): Path to the config file describing the tokenization setup.
+        config_dict (dict): Dictionary containing the configuration for the packed data generation.
     """
 
     # TODO: if we want to use alternative entrypoints together with the ResolverRegistry,
@@ -87,11 +86,10 @@ def pack_encoded_data(config_path: FilePath):
     #  One would requires an object of it to instantiate the ResolverRegistry.
     #  This could get resolved by implementing on own ResolverRegistry for each entrypoint or adapting the existing
     #  ResolverRegistry to work dynamically with any type-hinted config object from config.py.
-    config = load_app_config_dict(config_path)
     registry = Registry(COMPONENTS)
     component_factory = ComponentFactory(registry=registry)
     components: PackedDatasetComponentsInstantiationModel = component_factory.build_components(
-        config_dict=config, components_model_type=PackedDatasetComponentsInstantiationModel
+        config_dict=config_dict, components_model_type=PackedDatasetComponentsInstantiationModel
     )
 
     generator = PackedDataGenerator(

--- a/src/modalities/dataloader/create_index.py
+++ b/src/modalities/dataloader/create_index.py
@@ -27,11 +27,11 @@ class IndexGenerator:
         """
         self.src_file = src_file
         self.drop_faulty_entries = drop_faulty_entries
-        with self.src_file.open(mode="r") as fin:
+        with self.src_file.open(mode="rb") as fin:
             # Move the cursor to the end of the file
             fin.seek(0, os.SEEK_END)
-            # Get number of characters in the file
-            self._total_num_chars = fin.tell()
+            # Get number of bytes in the file
+            self._total_num_bytes = fin.tell()
         self._queue_of_raw_lines = queue.Queue()
         self._index_map = []
         self._exception_buffer = []
@@ -105,14 +105,14 @@ class IndexGenerator:
         # the end of the file is reached. Each line is put into a queue along with its cursor position. If any
         # errors are detected, the method returns immediately.
 
-        with open(self.src_file, "r") as fin:
+        with open(self.src_file, "rb") as fin:
             while True:
                 cursor = fin.tell()
                 line = fin.readline()
                 if self._check_for_parallel_errors():
                     return
-                if fin.tell() == self._total_num_chars:
-                    if line[-1] == "\n":
+                if fin.tell() == self._total_num_bytes:
+                    if line.endswith(b"\n"):
                         line = line[:-1]
                     self._queue_of_raw_lines.put((cursor, line))
                     break

--- a/src/modalities/dataloader/create_packed_data.py
+++ b/src/modalities/dataloader/create_packed_data.py
@@ -67,7 +67,7 @@ class PackedDataGenerator:
         self._encoded_eos_token_as_bytes = self._encoded_token_to_bytes(encoded_eod_token)
         self.jq_filter = jq.compile(jq_pattern)
         self._number_of_processes = number_of_processes
-        self._reader = LargeFileLinesReader(src_path, index_path=index_path)
+        self._reader = LargeFileLinesReader(src_path, index_path=index_path)  # reads string with utf-8 encoding
         self._total_num_of_tokens = 0
         self._raw_samples_queue = multiprocessing.Queue(maxsize=raw_samples_queue_size)
         self.processed_samples_queue = multiprocessing.Queue(maxsize=processed_samples_queue_size)
@@ -251,7 +251,6 @@ class PackedDataGenerator:
         def reader():
             batch = []
             for line_id, line in tqdm(enumerate(self._reader), desc="Reading jsonl", disable=True):
-                # line = self._reader[line_id]
                 batch.append((line_id, line))
                 if len(batch) % self.processing_batch_size == 0:
                     self._raw_samples_queue.put(batch)
@@ -290,7 +289,7 @@ class PackedDataGenerator:
                 )
             except Exception as exception:
                 warnings.warn(
-                    f"Could not process line of number {line_id} within process {process_id}. "
+                    f"Could not process line {line_id} in {self.src_path} within process {process_id}. "
                     f"Raised the following error: {exception=}"
                 )
                 traceback.print_exc()

--- a/tests/dataloader/test_large_file_lines_reader.py
+++ b/tests/dataloader/test_large_file_lines_reader.py
@@ -11,27 +11,40 @@ from modalities.dataloader.large_file_lines_reader import LargeFileLinesReader
 from tests.conftest import DataPathCollection
 
 
-def create_dummy_data(tmpdir_path: Path, content: str) -> Path:
+def create_dummy_data(tmpdir_path: Path, byte_content: bytes) -> Path:
     random_temp_filename = Path(tempfile.NamedTemporaryFile(suffix=".txt").name).name
     dummy_data_path = Path(tmpdir_path, random_temp_filename)
-    dummy_data_path.write_text(content)
+    dummy_data_path.write_bytes(byte_content)
     return dummy_data_path
 
 
 @pytest.mark.parametrize(
-    "dummy_content_text",
-    [
-        "This is \na dummy text\nwith newline chars\nand other\\n randøm\nchars.\n"
-        "It also includes malformatted json chars, like\n{{\n",
-        "This is \na dummy text\nwith newline chars\nand other\\n randøm\nchars.\n"
-        "It also includes malformatted json chars, like\n{{\nbut does not come with a trailing newline char...",
+    "dummy_binary_content",
+    [  #  note the two bytes "\xc3\xb8" correspond to the character 'ø' when interpreted as utf-8
+        b"\xc3\xb8 This is \na dummy text\nwith newline chars\nand other\\n rand\xc3\xb8m\nchars.\n"
+        b"It also includes malformatted json chars, like\n{{\n",
+        b"This is \na dummy text\nwith newline chars\nand other\\n rand\xc3\xb8m\nchars.\n"
+        b"It also includes malformatted json chars, like\n{{\nbut does not come with a trailing newline char...",
     ],
 )
-def test_index_creation(tmpdir, dummy_content_text):
-    plain_text_data_path = create_dummy_data(tmpdir_path=Path(tmpdir), content=dummy_content_text)
-    jsonl_content_entries = [json.dumps(dict(text=s)) for s in dummy_content_text.split("\n")]
+def test_index_creation(tmpdir, dummy_binary_content: bytes):
+    # dumps the dummy content to a file
+    # e.g. the line "ø This is \na du"  is represented by the hex string:
+    # c3 b8 20 54 68 69 73 20  69 73 20 0a 61 20 64 75
+    # with c3 b8 corresponding to the utf-8 encoding of the character 'ø'.
+    # Note that when cat the file, the console already inteprets the bytes as utf-8,
+    # such that \xc3\xb8 is displayed as 'ø'.
+    # As a workaround, we can print the hex stream via: cat file.bin | hexdump -C.
+    plain_text_data_path = create_dummy_data(tmpdir_path=Path(tmpdir), byte_content=dummy_binary_content)
+
+    # we interpret the binary content as utf-8 to create a jsonl file
+    # \xc3\xb8 becomes 'ø' when interpreted as utf-8
+    dummy_content_text = dummy_binary_content.decode("utf-8")
+    # for each line in the dummy content, we create a json document with key 'text' and value of the line content
+    jsonl_content_entries = [json.dumps(dict(text=s), ensure_ascii=False) for s in dummy_content_text.split("\n")]
     jsonl_content = "\n".join(jsonl_content_entries)
-    jsonl_data_path = create_dummy_data(tmpdir_path=Path(tmpdir), content=jsonl_content)
+
+    jsonl_data_path = create_dummy_data(tmpdir_path=Path(tmpdir), byte_content=jsonl_content.encode("utf-8"))
     dummy_dst_path = Path(tmpdir, "index.pkl")
 
     def generate_data_index_file(data_path: Path, **kwargs):
@@ -44,12 +57,16 @@ def test_index_creation(tmpdir, dummy_content_text):
         with pytest.raises(ValueError):
             generate_data_index_file(plain_text_data_path)
         generate_data_index_file(plain_text_data_path, drop_faulty_entries=True)
+
+    # generate the index
     generate_data_index_file(jsonl_data_path)
 
+    # load the index to check if it is correct
     index = pickle.loads(dummy_dst_path.read_bytes())
-    assert [
-        json.loads(jsonl_content[offset : offset + length])["text"] for offset, length in index
-    ] == dummy_content_text.split("\n")
+    jsonl_content_binary = jsonl_content.encode("utf-8")
+    # json.loads implicitly decodes a binary stream as utf-8
+    loaded_data = [json.loads(jsonl_content_binary[offset : offset + length])["text"] for offset, length in index]
+    assert loaded_data == dummy_content_text.split("\n")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# What does this PR do?

The char-based index is not always consistent with the byte-based index.

For instance, the first character of the string "ø This is..." is written on disc as two bytes, namely \xc3\xb8, when encoded as utf-8. 
Therefore, the byte-based index has one more byte/char than the char-based index. 

For consistency, we don't consider any char-based indexes anymore and always refer to byte-based indexes. 


## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [x] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)
- [x] I have updated the internal changelog (`CHANGELOG_DEV.md`)