### PR TITLE
Bug fix: Only append eod token once when packing / tokenizing

### DIFF
--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -119,3 +119,12 @@ We can also now configure the encoding used for reading the documents. If encodi
 
 **Breaking Changes**
 * None
+
+
+## PR #280 Bugfix: the number of bytes per token were wrongly calculated
+
+This PR fixes the bytes per token calculation.
+Generally, we estimate how many bytes are needed to encode the full range of the vocabulary. 
+E.g., for a vocab size > 65536, we need 3 bytes for each token in the pbin file. 
+
+The calculation was wrong but coincidentally correct for the GPT2 tokenizer. 

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -128,3 +128,12 @@ Generally, we estimate how many bytes are needed to encode the full range of the
 E.g., for a vocab size > 65536, we need 3 bytes for each token in the pbin file. 
 
 The calculation was wrong but coincidentally correct for the GPT2 tokenizer. 
+
+
+
+## PR #281: The char-based index is not always consistent with the byte-based index.
+
+The first character of the string "ø This is..." is written on disc as two bytes, namely \xc3\xb8, when encoded as utf-8. 
+Therefore, the byte-based index has one more byte/char than the char-based index. 
+
+For consistency, we don't consider any char-based indexes anymore and always refer to byte-based indexes. 

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -121,7 +121,7 @@ We can also now configure the encoding used for reading the documents. If encodi
 * None
 
 
-## PR #280 Bugfix: the number of bytes per token were wrongly calculated
+## PR #280 Bug fix: the number of bytes per token were wrongly calculated
 
 This PR fixes the bytes per token calculation.
 Generally, we estimate how many bytes are needed to encode the full range of the vocabulary. 
@@ -131,9 +131,26 @@ The calculation was wrong but coincidentally correct for the GPT2 tokenizer.
 
 
 
-## PR #281: The char-based index is not always consistent with the byte-based index.
+## PR #281: Bug fix: The char-based index is not always consistent with the byte-based index.
 
 The first character of the string "ø This is..." is written on disc as two bytes, namely \xc3\xb8, when encoded as utf-8. 
 Therefore, the byte-based index has one more byte/char than the char-based index. 
 
 For consistency, we don't consider any char-based indexes anymore and always refer to byte-based indexes. 
+
+
+## PR #282: Bug fix: Enforce power of 2 number of bytes per token
+
+
+Previously, the number of bytes per token was calculated by `math.ceil(log_2(vocab_size)/8)`, leading to ranges between 1 and 4 bytes. 
+However, the dataset implementation only support 1, 2 and 4 bytes per token, as defined here
+
+https://github.com/Modalities/modalities/blob/0483362abac93e45850e56adaea7921e96836d59/src/modalities/dataloader/dataset.py#L202-L206
+
+and 
+
+https://github.com/Modalities/modalities/blob/0483362abac93e45850e56adaea7921e96836d59/src/modalities/dataloader/dataset.py#L233-L234
+
+I added a switch case that maps to the respective byte sizes, when packing the data.
+
+This adds some inefficiencies as a vobabulary size > 65536 already requires 4 bytes per token, effectively doubling the storage requirements. 

--- a/CHANGELOG_DEV.md
+++ b/CHANGELOG_DEV.md
@@ -154,3 +154,13 @@ https://github.com/Modalities/modalities/blob/0483362abac93e45850e56adaea7921e96
 I added a switch case that maps to the respective byte sizes, when packing the data.
 
 This adds some inefficiencies as a vobabulary size > 65536 already requires 4 bytes per token, effectively doubling the storage requirements. 
+
+
+## PR #283: Bug fix: Only append eod token once when packing / tokenizing
+
+Some HF tokenisers such as `xlm-roberta-large` add special tokens (e.g., eod token) automatically when encoding text, whereas others, such as `gpt2`, do not add special tokens. 
+
+This side-effect in the transformers library has lead to the eod token being appended twice when tokenizing / packing our data. We added a check for this and only append the eod token once now:
+https://github.com/Modalities/modalities/blob/1c1ccdc973283c45bc8c9fadf4d20f03e435cd04/src/modalities/dataloader/create_packed_data.py#L327-L330
+
+Additionally, I added a script that verifies the consistency of the indexation and tokenization of a given JSONL file. We run the indexation and tokenization routines in modalities and compare it to tokenized JSONL file to which we applied the HF tokenizer directly. 

--- a/src/modalities/__main__.py
+++ b/src/modalities/__main__.py
@@ -158,8 +158,9 @@ def CMD_entry_point_pack_encoded_data(config_path: FilePath):
     Args:
         config_path (FilePath): Path to the config file describing the tokenization setup.
     """
+    config_dict = load_app_config_dict(config_path)
 
-    pack_encoded_data(config_path=config_path)
+    pack_encoded_data(config_dict=config_dict)
 
 
 @data.command(name="merge_packed_data")

--- a/src/modalities/api.py
+++ b/src/modalities/api.py
@@ -8,7 +8,6 @@ from pydantic import FilePath
 import modalities.inference.inference as inference
 from modalities.checkpointing.checkpoint_conversion import CheckpointConversion
 from modalities.config.component_factory import ComponentFactory
-from modalities.config.config import load_app_config_dict
 from modalities.config.instantiation_models import PackedDatasetComponentsInstantiationModel
 from modalities.dataloader.create_index import IndexGenerator
 from modalities.dataloader.create_packed_data import EmbeddedStreamData, PackedDataGenerator, join_embedded_stream_data
@@ -71,14 +70,14 @@ def convert_pytorch_to_hf_checkpoint(
     return hf_model
 
 
-def pack_encoded_data(config_path: FilePath):
+def pack_encoded_data(config_dict: dict):
     """Packs and encodes an indexed, large jsonl-file.
     (see also `create_index` for more information)
     Returns .pbin-file, which can be inserted into a training process directly
     and does not require its original jsonl-file or the respective index file anymore.
 
     Args:
-        config_path (FilePath): Path to the config file describing the tokenization setup.
+        config_dict (dict): Dictionary containing the configuration for the packed data generation.
     """
 
     # TODO: if we want to use alternative entrypoints together with the ResolverRegistry,
@@ -87,11 +86,10 @@ def pack_encoded_data(config_path: FilePath):
     #  One would requires an object of it to instantiate the ResolverRegistry.
     #  This could get resolved by implementing on own ResolverRegistry for each entrypoint or adapting the existing
     #  ResolverRegistry to work dynamically with any type-hinted config object from config.py.
-    config = load_app_config_dict(config_path)
     registry = Registry(COMPONENTS)
     component_factory = ComponentFactory(registry=registry)
     components: PackedDatasetComponentsInstantiationModel = component_factory.build_components(
-        config_dict=config, components_model_type=PackedDatasetComponentsInstantiationModel
+        config_dict=config_dict, components_model_type=PackedDatasetComponentsInstantiationModel
     )
 
     generator = PackedDataGenerator(

--- a/src/modalities/dataloader/create_index.py
+++ b/src/modalities/dataloader/create_index.py
@@ -27,11 +27,11 @@ class IndexGenerator:
         """
         self.src_file = src_file
         self.drop_faulty_entries = drop_faulty_entries
-        with self.src_file.open(mode="r") as fin:
+        with self.src_file.open(mode="rb") as fin:
             # Move the cursor to the end of the file
             fin.seek(0, os.SEEK_END)
-            # Get number of characters in the file
-            self._total_num_chars = fin.tell()
+            # Get number of bytes in the file
+            self._total_num_bytes = fin.tell()
         self._queue_of_raw_lines = queue.Queue()
         self._index_map = []
         self._exception_buffer = []
@@ -105,14 +105,14 @@ class IndexGenerator:
         # the end of the file is reached. Each line is put into a queue along with its cursor position. If any
         # errors are detected, the method returns immediately.
 
-        with open(self.src_file, "r") as fin:
+        with open(self.src_file, "rb") as fin:
             while True:
                 cursor = fin.tell()
                 line = fin.readline()
                 if self._check_for_parallel_errors():
                     return
-                if fin.tell() == self._total_num_chars:
-                    if line[-1] == "\n":
+                if fin.tell() == self._total_num_bytes:
+                    if line.endswith(b"\n"):
                         line = line[:-1]
                     self._queue_of_raw_lines.put((cursor, line))
                     break

--- a/src/modalities/dataloader/create_packed_data.py
+++ b/src/modalities/dataloader/create_packed_data.py
@@ -3,6 +3,7 @@ import math
 import multiprocessing
 import os
 import pickle
+import traceback
 import warnings
 from io import BufferedWriter
 from pathlib import Path
@@ -84,7 +85,7 @@ class PackedDataGenerator:
         Returns:
             int: The number of bytes required to represent the integer.
         """
-        return math.ceil(math.log(math.log2(int_to_get_repr), 8))
+        return math.ceil(math.log2(int_to_get_repr) / 8)
 
     def _encoded_token_to_bytes(self, encoded_token: int) -> bytes:
         """
@@ -292,6 +293,7 @@ class PackedDataGenerator:
                     f"Could not process line of number {line_id} within process {process_id}. "
                     f"Raised the following error: {exception=}"
                 )
+                traceback.print_exc()
 
     def _update_data_length_in_pre_allocated_header(self, dst_path: Path, index_list: list[tuple[int, int]]):
         # Update the length of the data section in the pre-allocated header of the destination file.

--- a/src/modalities/dataloader/create_packed_data.py
+++ b/src/modalities/dataloader/create_packed_data.py
@@ -67,7 +67,7 @@ class PackedDataGenerator:
         self._encoded_eos_token_as_bytes = self._encoded_token_to_bytes(encoded_eod_token)
         self.jq_filter = jq.compile(jq_pattern)
         self._number_of_processes = number_of_processes
-        self._reader = LargeFileLinesReader(src_path, index_path=index_path)
+        self._reader = LargeFileLinesReader(src_path, index_path=index_path)  # reads string with utf-8 encoding
         self._total_num_of_tokens = 0
         self._raw_samples_queue = multiprocessing.Queue(maxsize=raw_samples_queue_size)
         self.processed_samples_queue = multiprocessing.Queue(maxsize=processed_samples_queue_size)
@@ -251,7 +251,6 @@ class PackedDataGenerator:
         def reader():
             batch = []
             for line_id, line in tqdm(enumerate(self._reader), desc="Reading jsonl", disable=True):
-                # line = self._reader[line_id]
                 batch.append((line_id, line))
                 if len(batch) % self.processing_batch_size == 0:
                     self._raw_samples_queue.put(batch)
@@ -290,7 +289,7 @@ class PackedDataGenerator:
                 )
             except Exception as exception:
                 warnings.warn(
-                    f"Could not process line of number {line_id} within process {process_id}. "
+                    f"Could not process line {line_id} in {self.src_path} within process {process_id}. "
                     f"Raised the following error: {exception=}"
                 )
                 traceback.print_exc()

--- a/src/modalities/dataloader/create_packed_data.py
+++ b/src/modalities/dataloader/create_packed_data.py
@@ -323,7 +323,10 @@ class PackedDataGenerator:
         tokens = self.tokenizer.tokenize(jq_retrieved_text)
         if len(tokens) == 0:
             raise EmptySampleError("Received empty sample...")
-        return b"".join(map(self._encoded_token_to_bytes, tokens)) + self._encoded_eos_token_as_bytes
+        token_byte_string = b"".join(map(self._encoded_token_to_bytes, tokens))
+        if not token_byte_string.endswith(self._encoded_eos_token_as_bytes):
+            token_byte_string = token_byte_string + self._encoded_eos_token_as_bytes
+        return token_byte_string
 
 
 class EmbeddedStreamData:

--- a/src/modalities/dataloader/create_packed_data.py
+++ b/src/modalities/dataloader/create_packed_data.py
@@ -85,7 +85,17 @@ class PackedDataGenerator:
         Returns:
             int: The number of bytes required to represent the integer.
         """
-        return math.ceil(math.log2(int_to_get_repr) / 8)
+        # we currently only supoprt token sizes of 1, 2 and 4 bytes, as implemented here:
+        # https://github.com/Modalities/modalities/blob/fix_char_bytes_indexation_mismatch/src/modalities/dataloader/dataset.py#L202
+        num_bytes = math.ceil(math.log2(int_to_get_repr) / 8)
+        if num_bytes == 1:
+            return 1
+        elif num_bytes == 2:
+            return 2
+        elif num_bytes <= 4:
+            return 4
+        else:
+            raise ValueError("Currently only support token byte sizes of 1, 2, and 4.")
 
     def _encoded_token_to_bytes(self, encoded_token: int) -> bytes:
         """

--- a/src/modalities/utils/verify_hf_tokenization_constistency.py
+++ b/src/modalities/utils/verify_hf_tokenization_constistency.py
@@ -1,0 +1,123 @@
+import json
+import os
+import pickle
+import tempfile
+import warnings
+from pathlib import Path
+
+import tqdm
+from transformers import AutoTokenizer
+
+from modalities.api import create_raw_data_index, pack_encoded_data
+from modalities.dataloader.dataset import PackedMemMapDatasetBase
+
+
+def run_tokenization(
+    src_path: Path, index_path: Path, pbin_path: Path, eod_token: str, hf_tokenizer_name: str, jq_pattern: str = ".text"
+):
+    # create index
+    create_raw_data_index(src_path=src_path, index_path=index_path)
+    # run tokenization
+    num_cpus = os.cpu_count()
+
+    tokenization_config_dict = {
+        "settings": {
+            "src_path": src_path,
+            "dst_path": pbin_path,
+            "index_path": index_path,
+            "jq_pattern": jq_pattern,
+            "num_cpus": num_cpus,
+            "eod_token": eod_token,
+            "processing_batch_size": 10,
+            "raw_samples_queue_size": 300,
+            "processed_samples_queue_size": 300,
+        },
+        "tokenizer": {
+            "component_key": "tokenizer",
+            "variant_key": "pretrained_hf_tokenizer",
+            "config": {"pretrained_model_name_or_path": hf_tokenizer_name, "padding": False, "max_length": 51200000},
+        },
+    }
+
+    pack_encoded_data(config_dict=tokenization_config_dict)
+
+
+def verify_index(src_path: Path, index_path: Path):
+    with open(src_path, "rb") as f:
+        jsonl_binary_string = f.read()
+
+    with open(src_path, "rb") as f:
+        binary_string_list = f.readlines()
+
+    with open(src_path, "r", encoding="utf-8") as f:
+        string_list = f.readlines()
+
+    with open(index_path, "rb") as f:
+        jsonl_index = pickle.load(f)
+
+    for i, (offset, length) in tqdm.tqdm(enumerate(jsonl_index), desc="Verifying index"):
+        # check that the index works correctly on the binary data
+        assert jsonl_binary_string[offset : offset + length] == binary_string_list[i][:-1]  # remove \n
+
+        # check that string when encoded with utf-8 matches the binary data
+        assert jsonl_binary_string[offset : offset + length] == string_list[i].encode("utf-8")[:-1]
+
+
+def verify_pbin(src_path: Path, pbin_path: Path, eod_token: str, hf_tokenizer_name: str, text_key: str = "text"):
+    dataset = PackedMemMapDatasetBase(raw_data_path=pbin_path, sample_key="text", load_index=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(hf_tokenizer_name)
+    eod_token_id = tokenizer.convert_tokens_to_ids(eod_token)
+    assert tokenizer.encode(eod_token, add_special_tokens=False) == [eod_token_id]
+
+    with open(src_path, "r", encoding="utf-8") as f:
+        string_list = f.readlines()
+    string_list_tokenized = [tokenizer.encode(json.loads(string)[text_key]) for string in string_list]
+
+    special_tokens = set([tokenizer.convert_tokens_to_ids(token) for token in tokenizer.special_tokens_map.values()])
+
+    for i in tqdm.tqdm(range(len(dataset)), desc="Verifying pbin"):
+        pbin_sample = dataset[i]["text"]
+        recomputed_sample = string_list_tokenized[i]
+
+        # make sure that only the last token is the eod token
+        # and that the second last token is not the eod token or any other special token
+        assert pbin_sample[-1] == eod_token_id
+        assert pbin_sample[-1] in special_tokens
+        assert pbin_sample[-2] != eod_token_id
+        assert pbin_sample[-2] not in special_tokens
+
+        # we need to check if tokenizer addas the eod token as
+        # some tokenizers don't add the eod token at the end of the string
+        # whereas modalities always adds the eod token at the end of the string
+        if recomputed_sample[-1] != eod_token_id:
+            assert recomputed_sample[-1] not in special_tokens
+            if i == 0:
+                warnings.warn("The last token of the tokenized string is not the eod token")
+            assert len(pbin_sample) - 1 == len(recomputed_sample)
+            assert all(pbin_sample[:-1] == recomputed_sample)
+        else:
+            assert len(pbin_sample) == len(recomputed_sample)
+            assert all(pbin_sample == recomputed_sample)
+
+
+def verify_tokenization_consistency(src_path: Path, eod_token: str, hf_tokenizer_name: str):
+    # run indeaxing and tokenization
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        index_path = Path(tmp_dir) / "index.idx"
+        pbin_path = Path(tmp_dir) / "data.pbin"
+        run_tokenization(src_path, index_path, pbin_path, eod_token, hf_tokenizer_name)
+
+        # verify the index
+        verify_index(src_path=src_path, index_path=index_path)
+        print("Index verified")
+        # verify the tokenized data
+        verify_pbin(src_path=src_path, pbin_path=pbin_path, eod_token=eod_token, hf_tokenizer_name=hf_tokenizer_name)
+        print("Tokenization verified")
+
+
+if __name__ == "__main__":
+    _src_path = Path("/raid/s3/opengptx/max_lue/modalities/tmp_data/00135.jsonl")
+    _eod_token = "<|endoftext|>"  # "</s>"
+    _hf_tokenizer_name = "gpt2"  # "xlm-roberta-large"
+    verify_tokenization_consistency(src_path=_src_path, eod_token=_eod_token, hf_tokenizer_name=_hf_tokenizer_name)

--- a/tests/dataloader/test_large_file_lines_reader.py
+++ b/tests/dataloader/test_large_file_lines_reader.py
@@ -11,27 +11,40 @@ from modalities.dataloader.large_file_lines_reader import LargeFileLinesReader
 from tests.conftest import DataPathCollection
 
 
-def create_dummy_data(tmpdir_path: Path, content: str) -> Path:
+def create_dummy_data(tmpdir_path: Path, byte_content: bytes) -> Path:
     random_temp_filename = Path(tempfile.NamedTemporaryFile(suffix=".txt").name).name
     dummy_data_path = Path(tmpdir_path, random_temp_filename)
-    dummy_data_path.write_text(content)
+    dummy_data_path.write_bytes(byte_content)
     return dummy_data_path
 
 
 @pytest.mark.parametrize(
-    "dummy_content_text",
-    [
-        "This is \na dummy text\nwith newline chars\nand other\\n randøm\nchars.\n"
-        "It also includes malformatted json chars, like\n{{\n",
-        "This is \na dummy text\nwith newline chars\nand other\\n randøm\nchars.\n"
-        "It also includes malformatted json chars, like\n{{\nbut does not come with a trailing newline char...",
+    "dummy_binary_content",
+    [  #  note the two bytes "\xc3\xb8" correspond to the character 'ø' when interpreted as utf-8
+        b"\xc3\xb8 This is \na dummy text\nwith newline chars\nand other\\n rand\xc3\xb8m\nchars.\n"
+        b"It also includes malformatted json chars, like\n{{\n",
+        b"This is \na dummy text\nwith newline chars\nand other\\n rand\xc3\xb8m\nchars.\n"
+        b"It also includes malformatted json chars, like\n{{\nbut does not come with a trailing newline char...",
     ],
 )
-def test_index_creation(tmpdir, dummy_content_text):
-    plain_text_data_path = create_dummy_data(tmpdir_path=Path(tmpdir), content=dummy_content_text)
-    jsonl_content_entries = [json.dumps(dict(text=s)) for s in dummy_content_text.split("\n")]
+def test_index_creation(tmpdir, dummy_binary_content: bytes):
+    # dumps the dummy content to a file
+    # e.g. the line "ø This is \na du"  is represented by the hex string:
+    # c3 b8 20 54 68 69 73 20  69 73 20 0a 61 20 64 75
+    # with c3 b8 corresponding to the utf-8 encoding of the character 'ø'.
+    # Note that when cat the file, the console already inteprets the bytes as utf-8,
+    # such that \xc3\xb8 is displayed as 'ø'.
+    # As a workaround, we can print the hex stream via: cat file.bin | hexdump -C.
+    plain_text_data_path = create_dummy_data(tmpdir_path=Path(tmpdir), byte_content=dummy_binary_content)
+
+    # we interpret the binary content as utf-8 to create a jsonl file
+    # \xc3\xb8 becomes 'ø' when interpreted as utf-8
+    dummy_content_text = dummy_binary_content.decode("utf-8")
+    # for each line in the dummy content, we create a json document with key 'text' and value of the line content
+    jsonl_content_entries = [json.dumps(dict(text=s), ensure_ascii=False) for s in dummy_content_text.split("\n")]
     jsonl_content = "\n".join(jsonl_content_entries)
-    jsonl_data_path = create_dummy_data(tmpdir_path=Path(tmpdir), content=jsonl_content)
+
+    jsonl_data_path = create_dummy_data(tmpdir_path=Path(tmpdir), byte_content=jsonl_content.encode("utf-8"))
     dummy_dst_path = Path(tmpdir, "index.pkl")
 
     def generate_data_index_file(data_path: Path, **kwargs):
@@ -44,12 +57,16 @@ def test_index_creation(tmpdir, dummy_content_text):
         with pytest.raises(ValueError):
             generate_data_index_file(plain_text_data_path)
         generate_data_index_file(plain_text_data_path, drop_faulty_entries=True)
+
+    # generate the index
     generate_data_index_file(jsonl_data_path)
 
+    # load the index to check if it is correct
     index = pickle.loads(dummy_dst_path.read_bytes())
-    assert [
-        json.loads(jsonl_content[offset : offset + length])["text"] for offset, length in index
-    ] == dummy_content_text.split("\n")
+    jsonl_content_binary = jsonl_content.encode("utf-8")
+    # json.loads implicitly decodes a binary stream as utf-8
+    loaded_data = [json.loads(jsonl_content_binary[offset : offset + length])["text"] for offset, length in index]
+    assert loaded_data == dummy_content_text.split("\n")
 
 
 @pytest.mark.parametrize(

--- a/tests/dataloader/test_packed_dataset.py
+++ b/tests/dataloader/test_packed_dataset.py
@@ -263,7 +263,7 @@ def test_continuously_packed_index(token_size_in_bytes: int, block_size: int, to
 
 @pytest.mark.parametrize(
     "vocab_size, expected_num_bytes",
-    [(254, 1), (255, 1), (256, 1), (257, 2), (65534, 2), (65535, 2), (65536, 2), (65537, 3)],
+    [(254, 1), (255, 1), (256, 1), (257, 2), (65534, 2), (65535, 2), (65536, 2), (65537, 4), (65538, 4), (10000000, 4)],
 )
 def test__get_required_num_of_bytes_to_repr(vocab_size: int, expected_num_bytes: int):
     num_bytes = PackedDataGenerator._get_required_num_of_bytes_to_repr(int_to_get_repr=vocab_size)

--- a/tests/dataloader/test_packed_dataset.py
+++ b/tests/dataloader/test_packed_dataset.py
@@ -259,3 +259,12 @@ def test_continuously_packed_index(token_size_in_bytes: int, block_size: int, to
     )
 
     assert np.all(result_slow == result_vectorized)
+
+
+@pytest.mark.parametrize(
+    "vocab_size, expected_num_bytes",
+    [(254, 1), (255, 1), (256, 1), (257, 2), (65534, 2), (65535, 2), (65536, 2), (65537, 3)],
+)
+def test__get_required_num_of_bytes_to_repr(vocab_size: int, expected_num_bytes: int):
+    num_bytes = PackedDataGenerator._get_required_num_of_bytes_to_repr(int_to_get_repr=vocab_size)
+    assert expected_num_bytes == num_bytes


### PR DESCRIPTION
# What does this PR do?

Some HF tokenisers such as `xlm-roberta-large` add special tokens (e.g., eod token) automatically when encoding text, whereas others, such as `gpt2`, do not add special tokens. 

This side-effect in the transformers library has lead to the eod token being appended twice when tokenizing / packing our data. We added a check for this and only append the eod token once now:
https://github.com/Modalities/modalities/blob/1c1ccdc973283c45bc8c9fadf4d20f03e435cd04/src/modalities/dataloader/create_packed_data.py#L327-L330

Additionally, I added a script that verifies the consistency of the indexation and tokenization of a given JSONL file. We run the indexation and tokenization routines in modalities and compare it to tokenized JSONL file to which we applied the HF tokenizer directly. 


## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [ ] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [ ] I have checked that all tests run through (`python tests/tests.py`)
- [x] I have updated the internal changelog (`CHANGELOG_DEV.md`)