### PR TITLE
Make Hidden Dimension Configurable For SwiGLU

### DIFF
--- a/src/modalities/models/coca/multi_modal_decoder.py
+++ b/src/modalities/models/coca/multi_modal_decoder.py
@@ -50,7 +50,7 @@ class TransformerBlock(nn.Module):
         if activation == ActivationType.GELU:
             mlp = partial(MLP, in_features=n_embd, hidden_features=ffn_hidden, bias=bias, dropout=dropout)
         elif activation == ActivationType.SWIGLU:
-            mlp = partial(SwiGLU, n_embd=n_embd, bias=bias)
+            mlp = partial(SwiGLU, n_embd=n_embd, ffn_hidden=ffn_hidden, bias=bias)
         else:
             raise NotImplementedError(f"activation type {activation} not implemented")
 

--- a/src/modalities/models/gpt2/gpt2_model.py
+++ b/src/modalities/models/gpt2/gpt2_model.py
@@ -693,7 +693,7 @@ class GPT2Block(nn.Module):
         if activation_type == ActivationType.GELU:
             self.mlp = TransformerMLP(n_embd=n_embd, ffn_hidden=ffn_hidden, bias=bias, dropout=dropout)
         elif activation_type == ActivationType.SWIGLU:
-            self.mlp = SwiGLU(n_embd=n_embd, bias=bias)
+            self.mlp = SwiGLU(n_embd=n_embd, ffn_hidden=ffn_hidden, bias=bias)
         else:
             raise NotImplementedError("unimplemented activation")
 

--- a/src/modalities/models/model.py
+++ b/src/modalities/models/model.py
@@ -75,18 +75,20 @@ class NNModel(nn.Module):
 class SwiGLU(nn.Module):
     """SwiGLU class to define the SwiGLU activation function."""
 
-    def __init__(self, n_embd: int, bias: bool):
+    def __init__(self, n_embd: int, ffn_hidden: int, bias: bool):
         """
         Initializes the SwiGLU object.
 
         Args:
             n_embd (int): The number of embedding dimensions.
+            ffn_hidden (int): The number of hidden dimensions in the feed-forward network.
+            Best practice: 4 * n_embd (https://arxiv.org/pdf/1706.03762)
             bias (bool): Whether to include bias terms in the linear layers.
         """
 
         super().__init__()
 
-        hidden_dim = SwiGLU._get_hidden_dim(n_embd)
+        hidden_dim = SwiGLU._get_hidden_dim(ffn_hidden=ffn_hidden)
 
         self.W = nn.Linear(
             in_features=n_embd,
@@ -106,7 +108,7 @@ class SwiGLU(nn.Module):
         )
 
     @staticmethod
-    def _get_hidden_dim(n_embd: int) -> int:
+    def _get_hidden_dim(ffn_hidden: int) -> int:
         # Calculate the hidden dimension for the SwiGLU module based on the provided embedding dimension.
 
         # Best practice: 4 * n_embd (https://arxiv.org/pdf/1706.03762)
@@ -115,7 +117,7 @@ class SwiGLU(nn.Module):
         # 2 * (n_embd * hidden_dim) == 3 * (n_embd * 2/3 * hidden_dim)
         # Besides, we ensure that hidden_dim is the smallest multiple of
         # 256 that is greater than or equal the provided hidden_dim
-        return 256 * ((int(2 * 4 * n_embd / 3) + 256 - 1) // 256)
+        return 256 * ((int(2 * ffn_hidden / 3) + 256 - 1) // 256)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """

--- a/tests/nn/test_mlp.py
+++ b/tests/nn/test_mlp.py
@@ -14,14 +14,16 @@ def test_mlp_forward():
 
 def test_SwiGLU_forward():
     n_embd = 512
+    ffn_hidden = 4 * n_embd
     bias = True
-    mlp = SwiGLU(n_embd, bias)
+    mlp = SwiGLU(n_embd=n_embd, ffn_hidden=ffn_hidden, bias=bias)
 
     hidden_dim = 1536
-    assert SwiGLU._get_hidden_dim(n_embd) == hidden_dim
+    assert SwiGLU._get_hidden_dim(ffn_hidden=ffn_hidden) == hidden_dim
 
     n_embd = 511
-    assert SwiGLU._get_hidden_dim(n_embd) == hidden_dim
+    ffn_hidden = 4 * n_embd
+    assert SwiGLU._get_hidden_dim(ffn_hidden=ffn_hidden) == hidden_dim
 
     n_embd = 512
 


### PR DESCRIPTION
# What does this PR do?

This PR introduces a change to the SwiGLU activation by making the hidden dimension configurable. Previously, the hidden dimension was fixed (4 * `n_embd`), limiting flexibility in customizing the model architecture especially when using group query attention. This update enhances the usability of SwiGLU by allowing users to specify a custom hidden dimension during initialization.

## General Changes
* Add `ffn_hidden` to the SwiGLU module.

## Breaking Changes
* None

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [x] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)