### PR TITLE
Added sequential sampler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ noteboks/*
 tests/tmp/*
 *wandb_storage*
 .coverage/*
+eurolingua/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   rev: 23.9.1
   hooks:
   - id: black
-    language_version: python3.11
+    language_version: python3.12
     stages: [pre-commit]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.0.278

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   rev: 23.9.1
   hooks:
   - id: black
-    language_version: python3.12
+    language_version: python3.11
     stages: [pre-commit]
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.0.278

--- a/src/modalities/config/config.py
+++ b/src/modalities/config/config.py
@@ -192,7 +192,7 @@ class LinearLRSchedulerConfig(BaseModel):
     total_iters: Annotated[int, Field(strict=True, gt=0)]
     last_epoch: Annotated[int, Field(strict=True, ge=-1)] = -1
     verbose: bool = False
-    
+
 
 class CosineAnnealingLRSchedulerConfig(BaseModel):
     optimizer: PydanticOptimizerIFType
@@ -263,6 +263,10 @@ class PreTrainedHFTokenizerConfig(BaseModel):
 
 class PreTrainedSPTokenizerConfig(BaseModel):
     tokenizer_model_file: str
+
+
+class SequentialSamplerConfig(BaseModel):
+    data_source: PydanticDatasetIFType
 
 
 class DistributedSamplerConfig(BaseModel):

--- a/src/modalities/dataloader/shuffle_tokenized_data.py
+++ b/src/modalities/dataloader/shuffle_tokenized_data.py
@@ -70,7 +70,9 @@ def shuffle_tokenized_data(input_data_path: Path, output_data_path: Path, batch_
     random.shuffle(index_base)
 
     # Step 3: Divide the shuffled index into batches
-    batches: list[list[tuple[int, int]]] = [index_base[i : i + batch_size] for i in range(0, len(index_base), batch_size)]
+    batches: list[list[tuple[int, int]]] = [
+        index_base[i : i + batch_size] for i in range(0, len(index_base), batch_size)
+    ]
 
     header_data = data_section_length_in_bytes + token_size_as_bytes
 

--- a/src/modalities/registry/components.py
+++ b/src/modalities/registry/components.py
@@ -4,7 +4,7 @@ from typing import Callable, Type
 import torch
 import torch.nn as nn
 from pydantic import BaseModel
-from torch.utils.data import BatchSampler, DistributedSampler
+from torch.utils.data import BatchSampler, DistributedSampler, SequentialSampler
 
 from modalities.checkpointing.checkpoint_saving import CheckpointSaving
 from modalities.checkpointing.checkpoint_saving_strategies import (
@@ -34,8 +34,8 @@ from modalities.config.config import (
     FSDPCheckpointSavingConfig,
     FSDPWrappedModelConfig,
     GPT2LLMCollateFnConfig,
-    LLMDataLoaderConfig,
     LinearLRSchedulerConfig,
+    LLMDataLoaderConfig,
     MemMapDatasetConfig,
     OneCycleLRSchedulerConfig,
     PackedMemMapDatasetContinuousConfig,
@@ -47,6 +47,7 @@ from modalities.config.config import (
     RichResultSubscriberConfig,
     SaveEveryKStepsCheckpointingStrategyConfig,
     SaveKMostRecentCheckpointsStrategyConfig,
+    SequentialSamplerConfig,
     StepLRSchedulerConfig,
     TorchCheckpointLoadingConfig,
     WandBEvaluationResultSubscriberConfig,
@@ -182,6 +183,7 @@ COMPONENTS = [
     ComponentEntity("dataset", "dummy_dataset", DatasetFactory.get_dummy_dataset, DummyDatasetConfig),
     ComponentEntity("dataset", "combined", DatasetFactory.get_combined_dataset, CombinedDatasetConfig),
     # samplers
+    ComponentEntity("sampler", "sequential_sampler", SequentialSampler, SequentialSamplerConfig),
     ComponentEntity("sampler", "distributed_sampler", DistributedSampler, DistributedSamplerConfig),
     ComponentEntity(
         "sampler", "resumable_distributed_sampler", ResumableDistributedSampler, ResumableDistributedSamplerConfig

--- a/tests/dataloader/samplers/test_sequential_samplers.py
+++ b/tests/dataloader/samplers/test_sequential_samplers.py
@@ -1,3 +1,5 @@
+import pytest 
+
 from torch.utils.data import SequentialSampler, Dataset
 
 class DummyDataset(Dataset):
@@ -11,11 +13,13 @@ class DummyDataset(Dataset):
         return self.data[index]
 
 
-def test_distributed_setting():
-    num_samples = 10
+@pytest.mark.parametrize("num_samples, world_size", [
+    (10, 3),  
+    (15, 4),  
+])
+def test_distributed_setting(num_samples, world_size):
     dataset = DummyDataset(num_samples)
-    world_size = 3
-    samplers = [SequentialSampler(dataset)for _ in range(world_size)]
+    samplers = [SequentialSampler(dataset) for _ in range(world_size)]
     
     expected_indices = list(range(num_samples))
     # Ensures that all ranks receive the exact same samples in the same order

--- a/tests/dataloader/samplers/test_sequential_samplers.py
+++ b/tests/dataloader/samplers/test_sequential_samplers.py
@@ -1,0 +1,23 @@
+from torch.utils.data import SequentialSampler, Dataset
+
+class DummyDataset(Dataset):
+    def __init__(self, num_samples):
+        self.data = list(range(num_samples))
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, index):
+        return self.data[index]
+
+
+def test_distributed_setting():
+    num_samples = 10
+    # Ensure each rank gets same samples
+    dataset = DummyDataset(num_samples)
+    world_size = 3
+    samplers = [SequentialSampler(dataset)for _ in range(world_size)]
+    
+    expected_indices = list(range(num_samples))
+    
+    assert all(list(sampler) == expected_indices for sampler in samplers)

--- a/tests/dataloader/samplers/test_sequential_samplers.py
+++ b/tests/dataloader/samplers/test_sequential_samplers.py
@@ -1,6 +1,6 @@
-import pytest 
+import pytest
+from torch.utils.data import Dataset, SequentialSampler
 
-from torch.utils.data import SequentialSampler, Dataset
 
 class DummyDataset(Dataset):
     def __init__(self, num_samples):
@@ -13,14 +13,17 @@ class DummyDataset(Dataset):
         return self.data[index]
 
 
-@pytest.mark.parametrize("num_samples, world_size", [
-    (10, 3),  
-    (15, 4),  
-])
+@pytest.mark.parametrize(
+    "num_samples, world_size",
+    [
+        (10, 3),
+        (15, 4),
+    ],
+)
 def test_distributed_setting(num_samples, world_size):
     dataset = DummyDataset(num_samples)
     samplers = [SequentialSampler(dataset) for _ in range(world_size)]
-    
+
     expected_indices = list(range(num_samples))
     # Ensures that all ranks receive the exact same samples in the same order
     assert all(list(sampler) == expected_indices for sampler in samplers)

--- a/tests/dataloader/samplers/test_sequential_samplers.py
+++ b/tests/dataloader/samplers/test_sequential_samplers.py
@@ -13,11 +13,10 @@ class DummyDataset(Dataset):
 
 def test_distributed_setting():
     num_samples = 10
-    # Ensure each rank gets same samples
     dataset = DummyDataset(num_samples)
     world_size = 3
     samplers = [SequentialSampler(dataset)for _ in range(world_size)]
     
     expected_indices = list(range(num_samples))
-    
+    # Ensures that all ranks receive the exact same samples in the same order
     assert all(list(sampler) == expected_indices for sampler in samplers)


### PR DESCRIPTION
# What does this PR do?

This PR adds a `SequentialSampler` component.
Before, we only had a `ResumableDistributedSampler` which distributes the samples among all ranks (disjoint sets). For very small datasets this `ResumableDistributedSampler` leads to incomplete batches (or even empty batches on some ranks) when scaling up the ranks. 

As a workaround, the `SequentialSampler` can be used which replicates the data on all ranks instead. This way, the same loss is computed  on each rank. Since we always calculate the per-token loss, this has no effect on the total loss. 


## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [ ] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)