### PR TITLE
Test whether model is on meta device

### DIFF
--- a/tests/models/test_model_factory.py
+++ b/tests/models/test_model_factory.py
@@ -101,7 +101,5 @@ def test_is_model_on_meta_device_false():
 
 def test_is_model_on_meta_device_mixed_raises():
     model = MixedDeviceModel()
-    with pytest.raises(
-        ModelStateError, match="Either all or none of the parameters and buffers must be on meta device!"
-    ):
+    with pytest.raises(ModelStateError):
         ModelFactory._is_model_on_meta_device(model)

--- a/tests/models/test_model_factory.py
+++ b/tests/models/test_model_factory.py
@@ -96,7 +96,7 @@ def test_is_model_on_meta_device_true():
 
 def test_is_model_on_meta_device_false():
     model = AllRealDeviceModel()
-    assert ModelFactory._is_model_on_meta_device(model) is False
+    assert not ModelFactory._is_model_on_meta_device(model)
 
 
 def test_is_model_on_meta_device_mixed_raises():

--- a/tests/models/test_model_factory.py
+++ b/tests/models/test_model_factory.py
@@ -91,7 +91,7 @@ class MixedDeviceModel(nn.Module):
 
 def test_is_model_on_meta_device_true():
     model = AllMetaDeviceModel()
-    assert ModelFactory._is_model_on_meta_device(model) is True
+    assert ModelFactory._is_model_on_meta_device(model)
 
 
 def test_is_model_on_meta_device_false():


### PR DESCRIPTION
# What does this PR do?

This PR addresses https://github.com/Modalities/modalities/issues/338 by implementing unit tests for the `_is_model_on_meta_device` static method in `ModelFactory.`

The tests cover the following cases:

- All parameters and buffers on the meta device → returns `True`
- All parameters and buffers on a regular device (e.g., CPU) → returns `False`
- Mixed setup (some on meta, some not) → raises `ModelStateError`

## General Changes
* 

## Breaking Changes
* None.

## Checklist before submitting final PR
- [ ] My PR is minimal and addresses one issue in isolation
- [ ] I have merged the latest version of the target branch into this feature branch
- [ ] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [ ] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)