### PR TITLE
Added filtering logic for memmap files.

### DIFF
--- a/src/modalities/dataloader/create_packed_data.py
+++ b/src/modalities/dataloader/create_packed_data.py
@@ -258,7 +258,7 @@ class PackedDataGenerator:
                 # write index
                 f.write(pickle.dumps(index_list))
 
-            self._update_data_length_in_pre_allocated_header(dst_path, index_list)
+            _update_data_length_in_pre_allocated_header(dst_path, index_list)
 
         return writer
 
@@ -310,17 +310,6 @@ class PackedDataGenerator:
                 )
                 traceback.print_exc()
 
-    def _update_data_length_in_pre_allocated_header(self, dst_path: Path, index_list: list[tuple[int, int]]):
-        # Update the length of the data section in the pre-allocated header of the destination file.
-        # The data segment length is sum of the starting position and the length of the last document.
-        length_of_byte_encoded_data_section = index_list[-1][0] + index_list[-1][1]
-        data_section_length_in_bytes = length_of_byte_encoded_data_section.to_bytes(
-            EmbeddedStreamData.DATA_SECTION_LENGTH_IN_BYTES, byteorder="little"
-        )
-        with dst_path.open("rb+") as fout:
-            fout.seek(0)
-            fout.write(data_section_length_in_bytes)
-
     def _process_line(self, line: str, process_id: int) -> bytes:
         # extracts the text via the jq_filter and applies tokenization to the extract text
         jq_retrieved_text = self.jq_filter.input_text(line).first()
@@ -333,6 +322,18 @@ class PackedDataGenerator:
         if not token_byte_string.endswith(self._encoded_eod_token_as_bytes):
             token_byte_string = token_byte_string + self._encoded_eod_token_as_bytes
         return token_byte_string
+
+
+def _update_data_length_in_pre_allocated_header(dst_path: Path, index_list: list[tuple[int, int]]):
+    # Update the length of the data section in the pre-allocated header of the destination file.
+    # The data segment length is sum of the starting position and the length of the last document.
+    length_of_byte_encoded_data_section = index_list[-1][0] + index_list[-1][1]
+    data_section_length_in_bytes = length_of_byte_encoded_data_section.to_bytes(
+        EmbeddedStreamData.DATA_SECTION_LENGTH_IN_BYTES, byteorder="little"
+    )
+    with dst_path.open("rb+") as fout:
+        fout.seek(0)
+        fout.write(data_section_length_in_bytes)
 
 
 class EmbeddedStreamData:

--- a/src/modalities/dataloader/filter_packed_data.py
+++ b/src/modalities/dataloader/filter_packed_data.py
@@ -1,0 +1,55 @@
+import pickle
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+from numpy.typing import NDArray
+from tqdm import tqdm
+
+from modalities.dataloader.create_packed_data import EmbeddedStreamData, _update_data_length_in_pre_allocated_header
+from modalities.dataloader.dataset import PackedMemMapDatasetBase
+
+
+def filter_dataset(
+    dst_path: Path,
+    src_path: Path,
+    filter_func: Callable[[tuple[int, dict[str, NDArray[np.int_]]]], bool],
+    sample_key: str = "input_ids",
+) -> None:
+    """
+    Filters the dataset based on a given filter function and writes the filtered data to the destination path.
+    Args:
+        dst_path (Path): The path where the filtered dataset will be written.
+        src_path (Path): The path to the source dataset to filter.
+        filter_func (Callable[[tuple[int, dict[str, NDArray[np.int_]]]], bool]):
+            A function that takes a sample index and its content and returns
+            True if the sample should be included, False otherwise.
+        sample_key (str): The key in the dataset samples to filter on, default is "input_ids".
+    Returns:
+        None
+    """
+    index_list: list[tuple[int, int]] = []
+    source_data = PackedMemMapDatasetBase(src_path, sample_key=sample_key, load_index=True)
+    with dst_path.open("wb") as f_out:
+        # allocate first self.header_size_in_bytes bytes for header (encodes length of data section)
+        # not possible to prepend header after determining size of data section
+        f_out.write((0).to_bytes(EmbeddedStreamData.DATA_SECTION_LENGTH_IN_BYTES, byteorder="little"))
+        tok_size = source_data.token_size_in_bytes
+        tok_type = np.dtype(f"uint{tok_size * 8}")
+        f_out.write(tok_size.to_bytes(EmbeddedStreamData.TOKEN_SIZE_DESCRIPTOR_LENGTH_IN_BYTES, byteorder="little"))
+        # The offset only applies to the data section, not the header
+        # When we load the file, we add the header size to the offset
+        curr_offset = 0
+
+        for _, entry in filter(filter_func, enumerate(tqdm(source_data, desc="Filtering samples"))):
+            tokens: NDArray[np.int_] = entry["input_ids"].astype(tok_type)
+            tokens = tokens.astype(tokens.dtype.newbyteorder("<"))
+            tokens_as_bytes = tokens.tobytes()
+            f_out.write(tokens_as_bytes)
+            segment_length = len(tokens_as_bytes)
+            index_list.append((curr_offset, segment_length))
+            curr_offset += segment_length
+        # write index
+        f_out.write(pickle.dumps(index_list))
+
+    _update_data_length_in_pre_allocated_header(dst_path, index_list)

--- a/tests/dataloader/test_filter_packed_data.py
+++ b/tests/dataloader/test_filter_packed_data.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+
+import numpy as np
+from numpy.typing import NDArray
+
+from modalities.dataloader.dataset import PackedMemMapDatasetBase
+from modalities.dataloader.filter_packed_data import filter_dataset
+
+
+def test_creates_output_file(tmp_path: Path, dummy_packed_data_path: Path):
+    output_path = Path(tmp_path, "output.pbin")
+    filter_dataset(
+        dst_path=output_path, src_path=dummy_packed_data_path, filter_func=accept_even_indices, sample_key="input_ids"
+    )
+    assert output_path.exists()
+
+
+def test_filtered_data_has_expected_length(tmp_path: Path, dummy_packed_data_path: Path):
+    output_path = Path(tmp_path, "output.pbin")
+    filter_dataset(
+        dst_path=output_path, src_path=dummy_packed_data_path, filter_func=accept_even_indices, sample_key="input_ids"
+    )
+    filtered_data = PackedMemMapDatasetBase(output_path, sample_key="input_ids")
+    assert len(filtered_data) == 2
+
+
+def test_filtered_data_has_expected_content(tmp_path: Path, dummy_packed_data_path: Path):
+    output_path = Path(tmp_path, "output.pbin")
+    filter_dataset(
+        dst_path=output_path, src_path=dummy_packed_data_path, filter_func=accept_even_indices, sample_key="input_ids"
+    )
+    filtered_data = PackedMemMapDatasetBase(output_path, sample_key="input_ids")
+    assert filtered_data[0]["input_ids"].tolist() == list(range(24 // 4))
+    assert filtered_data[1]["input_ids"].tolist() == list(range(64 // 4, (64 + 12) // 4))
+
+
+def accept_even_indices(idx_content: tuple[int, dict[str, NDArray[np.int_]]]) -> bool:
+    """
+    Filter function that accepts only even indices.
+    Args:
+        idx (int): The index of the sample.
+        content (Any): The content of the sample (not used in this filter).
+    Returns:
+        bool: True if the index is even, False otherwise.
+    """
+    idx, _ = idx_content
+    return idx % 2 == 0


### PR DESCRIPTION
# What does this PR do?

This PR adds a filtering function for the files produced by create pack data.
The filtering uses a filter function that takes the index and content of each sample and returns True iff that sample should be retained in the data.
iterates over the data in the file and writes out a new file containing only the retained samples.

## General Changes
* New filtering
* Corresponding tests

## Checklist before submitting final PR
- [X] My PR is minimal and addresses one issue in isolation
- [X] I have merged the latest version of the target branch into this feature branch
- [X] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [X] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)