### PR TITLE
Fix github tests 

### DIFF
--- a/.github/workflows/tests_full.yml
+++ b/.github/workflows/tests_full.yml
@@ -27,7 +27,7 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         export FLASH_ATTENTION_SKIP_CUDA_BUILD=TRUE
         python -m pip install ninja                   # Lowers compilation time of flash attention significantly 
-        python -m pip install flash-attn --no-build-isolation
+        python -m pip install flash-attn==2.7.4.post1 --no-build-isolation
         python -m pip install -e .[tests]
     - name: Run tests
       run: |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ conda activate modalities
 # install PyTorch, Ninja and Flash Attention (mandatory)
 pip install torch==2.6.0
 pip install ninja     # Lowers compilation time of flash attention significantly 
-pip install flash-attn --no-build-isolation
+pip install flash-attn==2.7.4.post1 --no-build-isolation
 ```
 
 ### Option 1: Installation from source


### PR DESCRIPTION
# What does this PR do?

This PR fixes the failing github tests by pinning the flash attention version to `flash-attn==2.7.4.post1`.

Before: https://github.com/Modalities/modalities/actions/runs/16045757395/job/45276575510
After: https://github.com/Modalities/modalities/actions/runs/16074134507/job/45365224015

## General Changes
* None

## Breaking Changes
* None

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)