### PR TITLE
Decrease micro batch size in IT tutorial config

### DIFF
--- a/tutorials/instruction_tuning/configs/small_train_instruct_model_fsdp2_config.yaml
+++ b/tutorials/instruction_tuning/configs/small_train_instruct_model_fsdp2_config.yaml
@@ -23,8 +23,8 @@ settings:
     enforce_last_step_evaluated: false
     enforce_last_step_checkpointed: false
   step_profile:
-    gradient_accumulation_steps: 2
-    local_train_micro_batch_size: 2
+    gradient_accumulation_steps: 4
+    local_train_micro_batch_size: 1
     sequence_length: 8192 # Qwen2.5 would have 32768
   training_target:
   # had to hack here: Value error, Not enough tokens in the dataset. Actual: 57434112, Expected: >=57442304


### PR DESCRIPTION
# What does this PR do?

The [instruction tuning (IT) example test](https://github.com/Modalities/modalities/blob/bef78d494c2df1863c59adf99d858f21fd04ff2d/tests/tests.py#L294) leads to an OOM error on A100s with 40GB RAM.

This PR solves the problem by simply decreasing the micro batch size by a factor 2 (while increasing the gradient accumulation steps accordingly) in [small_train_instruct_model_fsdp2_config.yaml](https://github.com/Modalities/modalities/blob/main/tutorials/instruction_tuning/configs/small_train_instruct_model_fsdp2_config.yaml).

Note that I have NOT applied the same changes to [train_instruct_model_fsdp2_config.yaml](https://github.com/Modalities/modalities/blob/main/tutorials/instruction_tuning/configs/train_instruct_model_fsdp2_config.yaml), used in the tutorial.

## General Changes
* None

## Breaking Changes
* None 

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [x] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)