### PR TITLE
Fix of SwiGLU hidden not being multiple of world size

### DIFF
--- a/src/modalities/models/gpt2/gpt2_model.py
+++ b/src/modalities/models/gpt2/gpt2_model.py
@@ -319,7 +319,10 @@ class GPT2LLMConfig(BaseModel):
         ffn_norm_config (LayerNormWrapperConfig): Config for normalization of the feed-forward network.
         lm_head_norm_config (LayerNormWrapperConfig): Config for normalization of the language model head.
         use_weight_tying (bool): Whether to use weight tying.
-
+        seed: int = None: The random seed for reproducibility.
+        enforce_swiglu_hidden_dim_multiple_of (Optional[int]): If specified, enforces the hidden dimension
+            in the SwiGLU layer to be a multiple of this value. Note that this is only relevant if the
+            activation_type is SwiGLU. Defaults to None.
     """
 
     sample_key: str
@@ -344,6 +347,8 @@ class GPT2LLMConfig(BaseModel):
     ffn_norm_config: LayerNormWrapperConfig
     lm_head_norm_config: LayerNormWrapperConfig
     use_weight_tying: bool
+    seed: Optional[int] = None
+    enforce_swiglu_hidden_dim_multiple_of: Optional[int] = None
 
     @model_validator(mode="after")
     def check_divisibility(self) -> "GPT2LLMConfig":
@@ -695,6 +700,7 @@ class GPT2Block(nn.Module):
         ffn_hidden: int,
         attention_norm: nn.Module,
         ffn_norm: nn.Module,
+        enforce_swiglu_hidden_dim_multiple_of: Optional[int] = None,
     ):
         """
         Initializes the GPT2Block.
@@ -711,6 +717,9 @@ class GPT2Block(nn.Module):
             ffn_hidden (int): The size of the hidden layer in the feed-forward network.
             attention_norm (nn.Module): The normalization layer for attention.
             ffn_norm (nn.Module): The normalization layer for feed-forward network.
+            enforce_swiglu_hidden_dim_multiple_of (Optional[int]): If specified, enforces the
+                hidden dimension in the SwiGLU layer to be a multiple of this value. Note that this
+                is only relevant if the activation_type is SwiGLU. Defaults to None.
         """
         super().__init__()
         self.attention_norm = attention_norm
@@ -728,7 +737,12 @@ class GPT2Block(nn.Module):
         if activation_type == ActivationType.GELU:
             self.mlp = TransformerMLP(n_embd=n_embd, ffn_hidden=ffn_hidden, bias=bias, dropout=dropout)
         elif activation_type == ActivationType.SWIGLU:
-            self.mlp = SwiGLU(n_embd=n_embd, ffn_hidden=ffn_hidden, bias=bias)
+            self.mlp = SwiGLU(
+                n_embd=n_embd,
+                ffn_hidden=ffn_hidden,
+                bias=bias,
+                enforce_swiglu_hidden_dim_multiple_of=enforce_swiglu_hidden_dim_multiple_of,
+            )
         else:
             raise NotImplementedError("unimplemented activation")
 
@@ -781,6 +795,7 @@ class GPT2LLM(NNModel):
         lm_head_norm_config: LayerNormWrapperConfig,
         use_weight_tying: bool,
         seed: int = None,
+        enforce_swiglu_hidden_dim_multiple_of: Optional[int] = None,
     ):
         """
         Initializes the GPT2LLM object.
@@ -806,6 +821,9 @@ class GPT2LLM(NNModel):
             lm_head_norm_config (LayerNormWrapperConfig): Config for the language model head normalization module.
             seed (int, optional): The random seed. Defaults to None.
             use_weight_tying (bool): Whether to use weight tying.
+            enforce_swiglu_hidden_dim_multiple_of (Optional[int]): If specified, enforces
+                the hidden dimension in the SwiGLU layer to be a multiple of this value.
+                Note that this is only relevant if the activation_type is SwiGLU. Defaults to None.
         """
         weight_decay_groups = {
             "linear": [".attn", ".mlp", ".lm_head.weight"],
@@ -861,6 +879,7 @@ class GPT2LLM(NNModel):
                             # a meta device!
                             attention_norm=attention_norm_config.norm_type.value(**dict(attention_norm_config.config)),
                             ffn_norm=ffn_norm_config.norm_type.value(**dict(ffn_norm_config.config)),
+                            enforce_swiglu_hidden_dim_multiple_of=enforce_swiglu_hidden_dim_multiple_of,
                         )
                         for _ in range(n_layer)
                     ]

--- a/src/modalities/models/model_factory.py
+++ b/src/modalities/models/model_factory.py
@@ -567,7 +567,8 @@ class GPT2ModelFactory:
         lm_head_norm_config: LayerNormWrapperConfig,
         use_weight_tying: bool,
         use_meta_device: Optional[bool] = False,
-        seed: int = None,
+        seed: Optional[int] = None,
+        enforce_swiglu_hidden_dim_multiple_of: Optional[int] = None,
     ) -> GPT2LLM:
         config = dict(
             sample_key=sample_key,
@@ -590,6 +591,7 @@ class GPT2ModelFactory:
             lm_head_norm_config=lm_head_norm_config,
             seed=seed,
             use_weight_tying=use_weight_tying,
+            enforce_swiglu_hidden_dim_multiple_of=enforce_swiglu_hidden_dim_multiple_of,
         )
         if use_meta_device and use_weight_tying:
             raise ValueError(


### PR DESCRIPTION
# What does this PR do?

This PR fixe an issue that occurs when using SwiGLU in a FSDP2 + TP combination. 
Since the hidden dim is computed dynamically to compensate for the difference in the number of trainable weights in comparison to GeLU, we end up with hidden dims that are not a multiple of the world size. 

This in return creates a problem when applying TP and subsequently FSDP2, as uneven sharding is not allowed for FSDP2 + TP (yet). The issue does not occur when only using FSDP2, as FSDP2 already support uneven sharding out of the box. 


## General Changes
* ..

## Breaking Changes
* .. 

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [x] I have run a sample config for model training
- [ ] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)