### PR TITLE
Fixes eager conversion on GPU

### DIFF
--- a/src/modalities/conversion/gpt2/modeling_gpt2.py
+++ b/src/modalities/conversion/gpt2/modeling_gpt2.py
@@ -161,7 +161,9 @@ def eager_attention_forward(
         causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
         attn_weights = attn_weights + causal_mask
 
-    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    # Note we do not upcast the attention weights to float32 here, as it introduces
+    # noise in the attention weights and is not necessary when using BF16
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=query.dtype)
     attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
     attn_output = torch.matmul(attn_weights, value_states)
     attn_output = attn_output.transpose(1, 2).contiguous()
@@ -479,14 +481,16 @@ class GPT2ForCausalLM(GPT2PreTrainedModel, GenerationMixin):
         )
 
 
-class GPT2ForSequenceClassification(GenericForSequenceClassification, GPT2PreTrainedModel): ...
+class GPT2ForSequenceClassification(GenericForSequenceClassification, GPT2PreTrainedModel):
+    ...
 
 
 class GPT2ForQuestionAnswering(GenericForQuestionAnswering, GPT2PreTrainedModel):
     base_model_prefix = "transformer"  # For BC, where `transformer` was used instead of `model`
 
 
-class GPT2ForTokenClassification(GenericForTokenClassification, GPT2PreTrainedModel): ...
+class GPT2ForTokenClassification(GenericForTokenClassification, GPT2PreTrainedModel):
+    ...
 
 
 __all__ = [


### PR DESCRIPTION
Reopening from https://github.com/Modalities/modalities/pull/392 now into main branch.  See original below:

# What does this PR do?

This PR fixes the conversion error we get when running the conversion in eager mode on GPU. It seems the upcasting to float32 with subsequent downcasting introduces errors into the attention_weights and therefore also the logits (see below plot). So it seems that historically this was added when using half-precision (fp16) as it has limited range and can easily overflow/underflow, which should be fixed with the extended range of BF16.

<img width="1184" height="1902" alt="comparison_differences" src="https://github.com/user-attachments/assets/4bdde907-e7bf-4677-bc69-15a542f7f954" />

The logits still are similar enough to produce similar outputs so thats why we see similar outputs even though the logits of the converted model are not the same
<img width="1495" height="631" alt="comparison_logits" src="https://github.com/user-attachments/assets/3a268b34-1fe2-412c-875a-c3b858219dc5" />

Not confirmed on main due to import errors from the updated transformers library, so comparing to the updating_and_fixing_conversion branch instead. 

## General Changes
* Changes the calculation of attn_weights to not upcast to float 32

## Checklist before submitting final PR
- [x] My PR is minimal and addresses one issue in isolation
- [x] I have merged the latest version of the target branch into this feature branch
- [x] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [ ] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)