### PR TITLE
Pipeline parallelism continued

### DIFF
--- a/config_files/training/config_lorem_ipsum_long_fsdp2_pp.yaml
+++ b/config_files/training/config_lorem_ipsum_long_fsdp2_pp.yaml
@@ -24,7 +24,7 @@ settings:
     enforce_last_step_checkpointed: false
   step_profile:
     gradient_accumulation_steps: 1
-    local_train_micro_batch_size: 2
+    local_train_micro_batch_size: 4
     sequence_length: 256
   training_target:
     num_target_tokens:
@@ -222,7 +222,7 @@ scheduled_pipeline:
       pass_type: BY_REFERENCE
     pp_schedule_name: gpipe
     batch_size: ${settings.step_profile.local_train_micro_batch_size}
-    microbatch_size: 1
+    microbatch_size: 2
     pp_degree: ${device_mesh.config.pipeline_parallel_degree}
      # maybe better to use the fsdp model and the schedule here
      # instead of passing in the staged pipeline?

--- a/src/modalities/config/instantiation_models.py
+++ b/src/modalities/config/instantiation_models.py
@@ -13,6 +13,7 @@ from modalities.config.pydantic_if_types import (
     PydanticLossIFType,
     PydanticMessageSubscriberIFType,
     PydanticMFUCalculatorABCType,
+    PydanticPipelineType,
     PydanticPytorchDeviceType,
     PydanticPytorchModuleType,
     PydanticTextInferenceComponentType,
@@ -178,6 +179,7 @@ class TrainingComponentsInstantiationModel(BaseModel):
     checkpoint_saving: PydanticCheckpointSavingIFType
     gradient_clipper: PydanticGradientClipperIFType
     mfu_calculator: Optional[PydanticMFUCalculatorABCType] = None
+    scheduled_pipeline: Optional[PydanticPipelineType] = None
     model_raw: PydanticPytorchModuleType
 
     @model_validator(mode="after")

--- a/src/modalities/config/instantiation_models.py
+++ b/src/modalities/config/instantiation_models.py
@@ -181,7 +181,7 @@ class TrainingComponentsInstantiationModel(BaseModel):
     gradient_clipper: PydanticGradientClipperIFType
     mfu_calculator: Optional[PydanticMFUCalculatorABCType] = None
     scheduled_pipeline: Optional[PydanticPipelineType] = None
-    device_mesh: PydanticDeviceMeshIFType
+    device_mesh: Optional[PydanticDeviceMeshIFType] = None
     model_raw: PydanticPytorchModuleType
 
     @model_validator(mode="after")

--- a/src/modalities/config/instantiation_models.py
+++ b/src/modalities/config/instantiation_models.py
@@ -8,6 +8,7 @@ from modalities.config.pydantic_if_types import (
     PydanticAppStateType,
     PydanticCheckpointSavingIFType,
     PydanticDatasetIFType,
+    PydanticDeviceMeshIFType,
     PydanticGradientClipperIFType,
     PydanticLLMDataLoaderIFType,
     PydanticLossIFType,
@@ -180,6 +181,7 @@ class TrainingComponentsInstantiationModel(BaseModel):
     gradient_clipper: PydanticGradientClipperIFType
     mfu_calculator: Optional[PydanticMFUCalculatorABCType] = None
     scheduled_pipeline: Optional[PydanticPipelineType] = None
+    device_mesh: PydanticDeviceMeshIFType
     model_raw: PydanticPytorchModuleType
 
     @model_validator(mode="after")

--- a/src/modalities/gym.py
+++ b/src/modalities/gym.py
@@ -106,7 +106,7 @@ class Gym:
         evaluation_interval_in_steps: int,
         scheduled_pipeline=None,  # TODO set type
     ):
-        if num_train_steps_done % evaluation_interval_in_steps == 0 and num_train_steps_done > 10:
+        if num_train_steps_done % evaluation_interval_in_steps == 0:
             self.evaluator.evaluate(
                 model=model,
                 data_loaders=evaluation_data_loaders,

--- a/src/modalities/gym.py
+++ b/src/modalities/gym.py
@@ -106,7 +106,7 @@ class Gym:
         evaluation_interval_in_steps: int,
         scheduled_pipeline=None,  # TODO set type
     ):
-        if num_train_steps_done % evaluation_interval_in_steps == 0:
+        if num_train_steps_done > 0 and num_train_steps_done % evaluation_interval_in_steps == 0:
             self.evaluator.evaluate(
                 model=model,
                 data_loaders=evaluation_data_loaders,

--- a/src/modalities/gym.py
+++ b/src/modalities/gym.py
@@ -40,6 +40,7 @@ class Gym:
         train_data_loader: LLMDataLoader,
         evaluation_data_loaders: list[LLMDataLoader],
         checkpoint_saving: CheckpointSaving,
+        scheduled_pipeline=None,  # TODO set type
     ):
         """Runs the model training, including evaluation and checkpointing.
 
@@ -57,6 +58,7 @@ class Gym:
             model=app_state.model,
             evaluation_data_loaders=evaluation_data_loaders,
             evaluation_interval_in_steps=evaluation_interval_in_steps,
+            scheduled_pipeline=scheduled_pipeline,
         )
 
         checkpointing_callback: Callable[[TrainingProgress], None] = partial(
@@ -74,6 +76,7 @@ class Gym:
             evaluation_callback=evaluation_callback,
             checkpointing_callback=checkpointing_callback,
             training_log_interval_in_steps=training_log_interval_in_steps,
+            scheduled_pipeline=scheduled_pipeline,
         )
         print_rank_0(f"Training done at {datetime.now()}.")
 
@@ -101,11 +104,13 @@ class Gym:
         num_train_steps_done: int,
         evaluation_data_loaders: list[LLMDataLoader],
         evaluation_interval_in_steps: int,
+        scheduled_pipeline=None,  # TODO set type
     ):
-        if num_train_steps_done % evaluation_interval_in_steps == 0:
+        if num_train_steps_done % evaluation_interval_in_steps == 0 and num_train_steps_done > 10:
             self.evaluator.evaluate(
                 model=model,
                 data_loaders=evaluation_data_loaders,
                 loss_fun=self.loss_fun,
                 num_train_steps_done=num_train_steps_done,
+                scheduled_pipeline=scheduled_pipeline,
             )

--- a/src/modalities/loss_functions.py
+++ b/src/modalities/loss_functions.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import overload
 
 import torch
 from torch.nn import CrossEntropyLoss
@@ -31,9 +32,16 @@ class CLMCrossEntropyLoss(Loss):
         # Mean over the tokens in the local-batch (batch per rank)
         self.loss_fun = CrossEntropyLoss(reduction="mean")
 
+    @overload
     def __call__(self, forward_batch: InferenceResultBatch) -> torch.Tensor:
-        labels = forward_batch.get_targets(self.target_key)
-        lm_logits = forward_batch.get_predictions(self.prediction_key)
+        ...
+
+    @overload
+    def __call__(self, outputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        ...
+
+    def __call__(self, *args, **kwargs) -> torch.Tensor:
+        labels, lm_logits = self._parse_arguments(args, kwargs)
 
         # move labels to correct device to enable model parallelism
         labels = labels.to(lm_logits.device)
@@ -43,13 +51,40 @@ class CLMCrossEntropyLoss(Loss):
         loss = self.loss_fun(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
         return loss
 
-
-class CLMCrossEntropyLossPP(CLMCrossEntropyLoss):
-    def __call__(self, outputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
-        forward_batch = InferenceResultBatch(
-            predictions={self.prediction_key: outputs}, targets={self.target_key: targets}
-        )
-        return super().__call__(forward_batch)
+    def _parse_arguments(
+        self,
+        args: list[torch.Tensor] | list[InferenceResultBatch],
+        kwargs: dict[str, torch.Tensor] | dict[str, InferenceResultBatch],
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if len(args) == 1 and isinstance(args[0], InferenceResultBatch):
+            forward_batch = args[0]
+            labels = forward_batch.get_targets(self.target_key)
+            lm_logits = forward_batch.get_predictions(self.prediction_key)
+        elif "forward_batch" in kwargs and isinstance(kwargs["forward_batch"], InferenceResultBatch):
+            forward_batch = kwargs["forward_batch"]
+            labels = forward_batch.get_targets(self.target_key)
+            lm_logits = forward_batch.get_predictions(self.prediction_key)
+        elif len(args) == 2 and all(isinstance(arg, torch.Tensor) for arg in args):
+            lm_logits, labels = args
+        elif (
+            "outputs" in kwargs
+            and "targets" in kwargs
+            and isinstance(kwargs["outputs"], torch.Tensor)
+            and isinstance(kwargs["targets"], torch.Tensor)
+        ):
+            lm_logits = kwargs["outputs"]
+            labels = kwargs["targets"]
+        elif (
+            len(args) == 1
+            and "targets" in kwargs
+            and isinstance(args[0], torch.Tensor)
+            and isinstance(kwargs["targets"], torch.Tensor)
+        ):
+            lm_logits = args[0]
+            labels = kwargs["targets"]
+        else:
+            raise TypeError("Invalid arguments for CLMCrossEntropyLoss.__call__")
+        return labels, lm_logits
 
 
 def nce_loss(

--- a/src/modalities/loss_functions.py
+++ b/src/modalities/loss_functions.py
@@ -44,6 +44,14 @@ class CLMCrossEntropyLoss(Loss):
         return loss
 
 
+class CLMCrossEntropyLossPP(CLMCrossEntropyLoss):
+    def __call__(self, outputs: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        forward_batch = InferenceResultBatch(
+            predictions={self.prediction_key: outputs}, targets={self.target_key: targets}
+        )
+        return super().__call__(forward_batch)
+
+
 def nce_loss(
     embedding1: torch.Tensor, embedding2: torch.Tensor, device: torch.device, is_asymmetric: bool, temperature: float
 ) -> torch.Tensor:

--- a/src/modalities/main.py
+++ b/src/modalities/main.py
@@ -117,7 +117,10 @@ class Main:
             * components.settings.step_profile.gradient_accumulation_steps
             * components.settings.cuda_env.world_size
         )
-        num_data_parallel_ranks = get_num_data_parallel_ranks(components.device_mesh)
+        if components.device_mesh is None:
+            num_data_parallel_ranks = 1
+        else:
+            num_data_parallel_ranks = get_num_data_parallel_ranks(components.device_mesh)
         trainer = Trainer(
             global_rank=components.settings.cuda_env.global_rank,
             progress_publisher=progress_publisher,

--- a/src/modalities/main.py
+++ b/src/modalities/main.py
@@ -20,6 +20,7 @@ from modalities.logging_broker.publisher import MessagePublisher
 from modalities.logging_broker.subscriber import MessageSubscriberIF
 from modalities.registry.components import COMPONENTS
 from modalities.registry.registry import Registry
+from modalities.running_env.fsdp.device_mesh import get_num_data_parallel_ranks
 from modalities.trainer import Trainer
 from modalities.util import get_synced_experiment_id_of_run, get_total_number_of_trainable_parameters, print_rank_0
 
@@ -116,6 +117,7 @@ class Main:
             * components.settings.step_profile.gradient_accumulation_steps
             * components.settings.cuda_env.world_size
         )
+        num_data_parallel_ranks = get_num_data_parallel_ranks(components.device_mesh)
         trainer = Trainer(
             global_rank=components.settings.cuda_env.global_rank,
             progress_publisher=progress_publisher,
@@ -128,6 +130,7 @@ class Main:
             gradient_clipper=components.gradient_clipper,
             global_num_tokens_per_train_step=global_num_tokens_per_train_step,
             mfu_calculator=components.mfu_calculator,
+            num_data_parallel_ranks=num_data_parallel_ranks,
         )
 
         # Evaluator

--- a/src/modalities/main.py
+++ b/src/modalities/main.py
@@ -169,6 +169,7 @@ class Main:
             checkpointing_interval_in_steps=components.settings.intervals.checkpointing_interval_in_steps,
             evaluation_interval_in_steps=components.settings.intervals.evaluation_interval_in_steps,
             training_log_interval_in_steps=components.settings.intervals.training_log_interval_in_steps,
+            scheduled_pipeline=components.scheduled_pipeline if components.scheduled_pipeline else None,
         )
 
     def get_logging_publishers(

--- a/src/modalities/models/gpt2/gpt2_model.py
+++ b/src/modalities/models/gpt2/gpt2_model.py
@@ -319,7 +319,7 @@ class GPT2LLMConfig(BaseModel):
         ffn_norm_config (LayerNormWrapperConfig): Config for normalization of the feed-forward network.
         lm_head_norm_config (LayerNormWrapperConfig): Config for normalization of the language model head.
         use_weight_tying (bool): Whether to use weight tying.
-
+        seed (int, optional): The seed for random number generation. Defaults to None.
     """
 
     sample_key: str
@@ -344,6 +344,7 @@ class GPT2LLMConfig(BaseModel):
     ffn_norm_config: LayerNormWrapperConfig
     lm_head_norm_config: LayerNormWrapperConfig
     use_weight_tying: bool
+    seed: Optional[int] = None
 
     @model_validator(mode="after")
     def check_divisibility(self) -> "GPT2LLMConfig":

--- a/src/modalities/models/model_factory.py
+++ b/src/modalities/models/model_factory.py
@@ -28,6 +28,7 @@ from modalities.config.config import ActivationCheckpointedModelConfig
 from modalities.exceptions import ModelStateError
 from modalities.models.gpt2.gpt2_model import (
     GPT2LLM,
+    GPT2LLMPP,
     AttentionConfig,
     AttentionImplementation,
     LayerNormWrapperConfig,
@@ -568,6 +569,7 @@ class GPT2ModelFactory:
         use_weight_tying: bool,
         use_meta_device: Optional[bool] = False,
         seed: int = None,
+        use_pp: Optional[bool] = False,
     ) -> GPT2LLM:
         config = dict(
             sample_key=sample_key,
@@ -597,11 +599,12 @@ class GPT2ModelFactory:
                 "Please set at least use_meta_device=False or use_weight_tying=False."
                 "https://github.com/Modalities/modalities/issues/357"
             )
+        gpt2_model_class = GPT2LLMPP if use_pp else GPT2LLM
         if use_meta_device:
             with torch.device("meta"):
-                model = GPT2LLM(**config)
+                model = gpt2_model_class(**config)
         else:
-            model = GPT2LLM(**config)
+            model = gpt2_model_class(**config)
         return model
 
     @staticmethod

--- a/src/modalities/models/model_factory.py
+++ b/src/modalities/models/model_factory.py
@@ -631,7 +631,7 @@ class GPT2ModelFactory:
             ),
         }
 
-        if isinstance(model.transformer.wpe, nn.Embedding):
+        if hasattr(model.transformer, "wpe") and isinstance(model.transformer.wpe, nn.Embedding):
             # If the position embedding is an nn.Embedding, we can shard it on the sequence dimension
             # to enable sequence parallelism in the downstream transformer blocks.
             # Note, for RoPE the wpe layer is an identity operation, which cannnot be sharded.
@@ -640,11 +640,14 @@ class GPT2ModelFactory:
                 output_layouts=Shard(0),
             )
 
-        parallelize_module(
-            module=model,
-            device_mesh=tp_mesh,
-            parallelize_plan=model_tp_plan,
-        )
+        # only keep the relevant parts of the model parallel plan
+        model_tp_plan = {k: v for k, v in model_tp_plan.items() if hasattr(model.transformer, k.split(".")[1])}
+        if model_tp_plan:
+            parallelize_module(
+                module=model,
+                device_mesh=tp_mesh,
+                parallelize_plan=model_tp_plan,
+            )
 
         transformer_block_tp_plan = {
             "attention_norm": SequenceParallel(),
@@ -703,6 +706,16 @@ class GPT2ModelFactory:
                 )
             transformer_block.attn.n_head_q = transformer_block.attn.n_head_q // tp_mesh.size()
             transformer_block.attn.n_head_kv = transformer_block.attn.n_head_kv // tp_mesh.size()
+            # only keep the relevant parts of the model parallel plan
+            transformer_block_tp_plan = {
+                k: v
+                for k, v in transformer_block_tp_plan.items()
+                if (
+                    hasattr(transformer_block, k)
+                    or hasattr(transformer_block.attn, k.split(".")[1])
+                    or hasattr(transformer_block.mlp, k.split(".")[1])
+                )
+            }
             parallelize_module(
                 module=transformer_block,
                 device_mesh=tp_mesh,

--- a/src/modalities/models/model_factory.py
+++ b/src/modalities/models/model_factory.py
@@ -28,7 +28,6 @@ from modalities.config.config import ActivationCheckpointedModelConfig
 from modalities.exceptions import ModelStateError
 from modalities.models.gpt2.gpt2_model import (
     GPT2LLM,
-    GPT2LLMPP,
     AttentionConfig,
     AttentionImplementation,
     LayerNormWrapperConfig,
@@ -569,7 +568,6 @@ class GPT2ModelFactory:
         use_weight_tying: bool,
         use_meta_device: Optional[bool] = False,
         seed: int = None,
-        use_pp: Optional[bool] = False,
     ) -> GPT2LLM:
         config = dict(
             sample_key=sample_key,
@@ -599,12 +597,11 @@ class GPT2ModelFactory:
                 "Please set at least use_meta_device=False or use_weight_tying=False."
                 "https://github.com/Modalities/modalities/issues/357"
             )
-        gpt2_model_class = GPT2LLMPP if use_pp else GPT2LLM
         if use_meta_device:
             with torch.device("meta"):
-                model = gpt2_model_class(**config)
+                model = GPT2LLM(**config)
         else:
-            model = gpt2_model_class(**config)
+            model = GPT2LLM(**config)
         return model
 
     @staticmethod

--- a/src/modalities/registry/components.py
+++ b/src/modalities/registry/components.py
@@ -78,7 +78,7 @@ from modalities.logging_broker.subscriber_impl.subscriber_factory import (
     ProgressSubscriberFactory,
     ResultsSubscriberFactory,
 )
-from modalities.loss_functions import CLMCrossEntropyLoss, CLMCrossEntropyLossPP
+from modalities.loss_functions import CLMCrossEntropyLoss
 from modalities.models.coca.coca_model import CoCa, CoCaConfig
 from modalities.models.coca.collator import CoCaCollateFnConfig, CoCaCollatorFn
 from modalities.models.components.layer_norms import LayerNormConfig, RMSLayerNorm, RMSLayerNormConfig
@@ -200,7 +200,6 @@ COMPONENTS = [
     ),
     # losses
     ComponentEntity("loss", "clm_cross_entropy_loss", CLMCrossEntropyLoss, CLMCrossEntropyLossConfig),
-    ComponentEntity("loss", "clm_cross_entropy_loss_pp", CLMCrossEntropyLossPP, CLMCrossEntropyLossConfig),
     # optmizers
     ComponentEntity("optimizer", "adam", OptimizerFactory.get_adam, AdamOptimizerConfig),
     ComponentEntity("optimizer", "adam_w", OptimizerFactory.get_adam_w, AdamWOptimizerConfig),

--- a/src/modalities/registry/components.py
+++ b/src/modalities/registry/components.py
@@ -112,8 +112,10 @@ from modalities.training.gradient_clipping.fsdp_gradient_clipper import (
 )
 from modalities.training.gradient_clipping.fsdp_gradient_clipper_config import (
     DummyGradientClipperConfig,
-    FSDPDummyGradientClipperConfig,
-    FSDPGradientClipperConfig,
+    FSDP1DummyGradientClipperConfig,
+    FSDP1GradientClipperConfig,
+    FSDP2DummyGradientClipperConfig,
+    FSDP2GradientClipperConfig,
 )
 from modalities.utils.mfu import GPT2MFUCalculator
 from modalities.utils.number_conversion import (
@@ -325,13 +327,13 @@ COMPONENTS = [
     ComponentEntity("layer_norm", "rms_norm", RMSLayerNorm, RMSLayerNormConfig),
     ComponentEntity("layer_norm", "layer_norm", nn.LayerNorm, LayerNormConfig),
     # gradient clippers
-    ComponentEntity("gradient_clipper", "fsdp1", FSDP1GradientClipper, FSDPGradientClipperConfig),
+    ComponentEntity("gradient_clipper", "fsdp1", FSDP1GradientClipper, FSDP1GradientClipperConfig),
     ComponentEntity(
-        "gradient_clipper", "fsdp1_logging_only", FSDP1LoggingOnlyGradientClipper, FSDPDummyGradientClipperConfig
+        "gradient_clipper", "fsdp1_logging_only", FSDP1LoggingOnlyGradientClipper, FSDP1DummyGradientClipperConfig
     ),
-    ComponentEntity("gradient_clipper", "fsdp2", FSDP2GradientClipper, FSDPGradientClipperConfig),
+    ComponentEntity("gradient_clipper", "fsdp2", FSDP2GradientClipper, FSDP2GradientClipperConfig),
     ComponentEntity(
-        "gradient_clipper", "fsdp2_logging_only", FSDP2LoggingOnlyGradientClipper, FSDPDummyGradientClipperConfig
+        "gradient_clipper", "fsdp2_logging_only", FSDP2LoggingOnlyGradientClipper, FSDP2DummyGradientClipperConfig
     ),
     ComponentEntity("gradient_clipper", "dummy", DummyGradientClipper, DummyGradientClipperConfig),
     # MFU calculators

--- a/src/modalities/registry/components.py
+++ b/src/modalities/registry/components.py
@@ -78,7 +78,7 @@ from modalities.logging_broker.subscriber_impl.subscriber_factory import (
     ProgressSubscriberFactory,
     ResultsSubscriberFactory,
 )
-from modalities.loss_functions import CLMCrossEntropyLoss
+from modalities.loss_functions import CLMCrossEntropyLoss, CLMCrossEntropyLossPP
 from modalities.models.coca.coca_model import CoCa, CoCaConfig
 from modalities.models.coca.collator import CoCaCollateFnConfig, CoCaCollatorFn
 from modalities.models.components.layer_norms import LayerNormConfig, RMSLayerNorm, RMSLayerNormConfig
@@ -200,6 +200,7 @@ COMPONENTS = [
     ),
     # losses
     ComponentEntity("loss", "clm_cross_entropy_loss", CLMCrossEntropyLoss, CLMCrossEntropyLossConfig),
+    ComponentEntity("loss", "clm_cross_entropy_loss_pp", CLMCrossEntropyLossPP, CLMCrossEntropyLossConfig),
     # optmizers
     ComponentEntity("optimizer", "adam", OptimizerFactory.get_adam, AdamOptimizerConfig),
     ComponentEntity("optimizer", "adam_w", OptimizerFactory.get_adam_w, AdamWOptimizerConfig),

--- a/src/modalities/running_env/fsdp/device_mesh.py
+++ b/src/modalities/running_env/fsdp/device_mesh.py
@@ -127,3 +127,25 @@ def get_device_mesh(
     # TODO: Torch Titan had some more checks here. We need to check if we also need those:
     # https://github.com/pytorch/torchtitan/blob/b291ad662493b63d25b038a30a915082d3617baf/torchtitan/distributed/parallel_dims.py#L86-L104
     return device_mesh
+
+
+def get_num_data_parallel_ranks(device_mesh: DeviceMesh) -> int:
+    """Gets the number of data parallel ranks from the device mesh.
+
+    Args:
+        device_mesh (DeviceMesh): The device mesh.
+
+    Returns:
+        int: The number of data parallel ranks.
+    """
+    world_size = device_mesh.size()
+    dp_size = world_size
+    for parallelism_degree in (
+        ParallelismDegrees.TP.value,
+        ParallelismDegrees.PP.value,
+        ParallelismDegrees.CP.value,
+    ):
+        if parallelism_degree in device_mesh.mesh_dim_names:
+            dp_size //= device_mesh.size(device_mesh.mesh_dim_names.index(parallelism_degree))
+
+    return dp_size

--- a/src/modalities/trainer.py
+++ b/src/modalities/trainer.py
@@ -30,6 +30,7 @@ class Trainer:
     def __init__(
         self,
         global_rank: int,
+        num_data_parallel_ranks: int,
         progress_publisher: MessagePublisher[ProgressUpdate],
         evaluation_result_publisher: MessagePublisher[EvaluationResultBatch],
         gradient_acc_steps: int,
@@ -62,6 +63,7 @@ class Trainer:
             None
         """
         self.global_rank = global_rank
+        self.num_data_parallel_ranks = num_data_parallel_ranks
         self.progress_publisher = progress_publisher
         self.evaluation_result_publisher = evaluation_result_publisher
         self.gradient_acc_steps = gradient_acc_steps
@@ -273,7 +275,9 @@ class Trainer:
                     operation=dist.ReduceOp.SUM,
                     # 1.) summed batch loss / (num batches * world size)
                     # 2.) last batch loss / world size
-                    post_processing_fun=lambda t: torch.stack([t[0] / t[-1], t[1] / dist.get_world_size()]),
+                    post_processing_fun=lambda t: torch.stack(
+                        [t[0] / t[-1], t[1] / self.num_data_parallel_ranks, t[-1]]
+                    ),
                 )
 
                 train_loss_avg, train_loss_last_batch = (

--- a/src/modalities/training/gradient_clipping/fsdp_gradient_clipper_config.py
+++ b/src/modalities/training/gradient_clipping/fsdp_gradient_clipper_config.py
@@ -6,7 +6,7 @@ from modalities.config.pydantic_if_types import PydanticDeviceMeshIFType, Pydant
 from modalities.training.gradient_clipping.fsdp_gradient_clipper import GradientClippingMode
 
 
-class FSDPGradientClipperConfig(BaseModel):
+class FSDP1GradientClipperConfig(BaseModel):
     """
     Configuration class for FSDP gradient clipper.
 
@@ -24,10 +24,44 @@ class FSDPGradientClipperConfig(BaseModel):
     max_norm: Annotated[float, Field(strict=True, gt=0)]
     norm_type: GradientClippingMode
     wrapped_model: PydanticPytorchModuleType
+
+
+class FSDP2GradientClipperConfig(FSDP1GradientClipperConfig):
+    """
+    Configuration class for FSDP gradient clipper.
+
+    Args:
+        max_norm (float): The maximum norm value for gradient clipping.
+        norm_type (GradientClippingMode): The type of gradient clipping to be applied.
+        wrapped_model (PydanticPytorchModuleType): The wrapped PyTorch model.
+
+    Attributes:
+        max_norm (float): The maximum norm value for gradient clipping.
+        norm_type (GradientClippingMode): The type of gradient clipping to be applied.
+        wrapped_model (PydanticPytorchModuleType): The wrapped PyTorch model.
+    """
+
     device_mesh: PydanticDeviceMeshIFType | None = None
 
 
-class FSDPDummyGradientClipperConfig(BaseModel):
+class FSDP1DummyGradientClipperConfig(BaseModel):
+    """
+    Configuration class for FSDP dummy gradient clipper.
+
+    Args:
+        wrapped_model (PydanticPytorchModuleType): The wrapped PyTorch model.
+        norm_type (GradientClippingMode): The type of gradient clipping to be applied.
+
+    Attributes:
+        wrapped_model (PydanticPytorchModuleType): The wrapped PyTorch model.
+        norm_type (GradientClippingMode): The type of gradient clipping to be applied.
+    """
+
+    wrapped_model: PydanticPytorchModuleType
+    norm_type: GradientClippingMode
+
+
+class FSDP2DummyGradientClipperConfig(FSDP1DummyGradientClipperConfig):
     """
     Configuration class for FSDP dummy gradient clipper.
 

--- a/src/modalities/training/gradient_clipping/fsdp_gradient_clipper_config.py
+++ b/src/modalities/training/gradient_clipping/fsdp_gradient_clipper_config.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from pydantic import BaseModel, Field
 
-from modalities.config.pydantic_if_types import PydanticPytorchModuleType
+from modalities.config.pydantic_if_types import PydanticDeviceMeshIFType, PydanticPytorchModuleType
 from modalities.training.gradient_clipping.fsdp_gradient_clipper import GradientClippingMode
 
 
@@ -24,6 +24,7 @@ class FSDPGradientClipperConfig(BaseModel):
     max_norm: Annotated[float, Field(strict=True, gt=0)]
     norm_type: GradientClippingMode
     wrapped_model: PydanticPytorchModuleType
+    device_mesh: PydanticDeviceMeshIFType | None = None
 
 
 class FSDPDummyGradientClipperConfig(BaseModel):
@@ -41,6 +42,7 @@ class FSDPDummyGradientClipperConfig(BaseModel):
 
     wrapped_model: PydanticPytorchModuleType
     norm_type: GradientClippingMode
+    device_mesh: PydanticDeviceMeshIFType | None = None
 
 
 class DummyGradientClipperConfig(BaseModel):

--- a/src/modalities/util.py
+++ b/src/modalities/util.py
@@ -186,9 +186,11 @@ def get_total_number_of_trainable_parameters(model: FSDPX) -> Number:
         # However, users can also provide their own sharding process groups (currently not supported in Modalities)
         # which would require to adapt the code.
         if model.sharding_strategy.name == "NO_SHARD":
-            sharding_factor = dist.get_world_size()
+            sharding_factor = dist.get_world_size()  # TODO Check if we should use number of data parallel ranks instead
         if model.sharding_strategy.name == "HYBRID_SHARD":
-            sharding_factor = dist.get_world_size() // torch.cuda.device_count()
+            sharding_factor = (
+                dist.get_world_size() // torch.cuda.device_count()
+            )  # TODO Check if we should use number of data parallel ranks instead
         elif model.sharding_strategy.name == "FULL_SHARD":
             sharding_factor = 1
         total_num_params = total_num_params // sharding_factor

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,6 +196,7 @@ def trainer(progress_publisher_mock, gradient_clipper_mock):
         global_num_seen_tokens=0,
         num_target_tokens=100,
         num_target_steps=10,
+        num_data_parallel_ranks=int(os.getenv("WORLD_SIZE")),
     )
 
 

--- a/tests/fsdp2_parallelization/pipeline_parallelism/configs/config_lorem_ipsum_long_fsdp2_fwd_bwd_pass.yaml
+++ b/tests/fsdp2_parallelization/pipeline_parallelism/configs/config_lorem_ipsum_long_fsdp2_fwd_bwd_pass.yaml
@@ -16,7 +16,7 @@ settings:
 
 loss_fn:
   component_key: loss
-  variant_key: clm_cross_entropy_loss_pp
+  variant_key: clm_cross_entropy_loss
   config:
     target_key: ${settings.referencing_keys.target_key}
     prediction_key: ${settings.referencing_keys.prediction_key}
@@ -27,7 +27,6 @@ device_mesh:
   config:
     device_type: cuda
     data_parallel_replicate_degree: 1
-    pipeline_parallel_degree: 2
     data_parallel_shard_degree: -1
     world_size: ${settings.cuda_env.world_size}
 
@@ -36,13 +35,8 @@ initialized_model:
   variant_key: model_initialized
   config:
     model:
-      component_key: pipeline
-      variant_key: selector
-      config:
-        pipeline:
-          instance_key: scheduled_pipeline
-          pass_type: BY_REFERENCE
-        selection_type: MODEL_PART
+      instance_key: fsdp_model
+      pass_type: BY_REFERENCE
     model_initializer:
       component_key: model_initialization
       variant_key: composed
@@ -52,40 +46,13 @@ initialized_model:
         mean: 0.0
         std: 0.02
         num_layers: ${model_raw.config.n_layer}
-
-scheduled_pipeline:
-  component_key: pipeline
-  variant_key: scheduled
-  config:
-    loss_fn:
-      instance_key: loss_fn
-      pass_type: BY_REFERENCE
-    pp_schedule_name: gpipe
-    batch_size: ${settings.step_profile.local_train_micro_batch_size}
-    microbatch_size: 2
-    pp_degree: ${device_mesh.config.pipeline_parallel_degree}
-    pipeline:
-      component_key: pipeline
-      variant_key: builder
-      config:
-        pp_stage:
-          component_key: pipeline
-          variant_key: selector
-          config:
-            pipeline:
-              instance_key: staged_pipeline
-              pass_type: BY_REFERENCE
-            selection_type: PP_STAGE
-        model_part:
-          instance_key: fsdp_model
-          pass_type: BY_REFERENCE
         
 fsdp_model:
   component_key: model
   variant_key: fsdp2_wrapped
   config:
     model:
-      instance_key: model_part
+      instance_key: model_raw
       pass_type: BY_REFERENCE
     device_mesh:
       instance_key: device_mesh
@@ -95,41 +62,10 @@ fsdp_model:
       reduce_dtype: BF_16
     block_names: [GPT2Block]
 
-model_part:
-  component_key: pipeline
-  variant_key: selector
-  config:
-    pipeline:
-      instance_key: staged_pipeline
-      pass_type: BY_REFERENCE
-    selection_type: MODEL_PART
-
-staged_pipeline:
-  component_key: pipeline
-  variant_key: staged
-  config:
-    whole_model:
-      instance_key: model_raw
-      pass_type: BY_REFERENCE
-    stages_generator:
-      component_key: stages_generator
-      variant_key: gpt2_stages_generator
-      config:
-        num_model_layers: ${model_raw.config.n_layer}
-        input_layer_equivalence: 1
-        output_layer_equivalence: 1
-    device_mesh:
-      instance_key: device_mesh
-      pass_type: BY_REFERENCE
-    local_rank: ${settings.cuda_env.local_rank}
-    pp_schedule_name: gpipe
-    num_layers_per_stage: 4
-
 model_raw:
   component_key: model
   variant_key: gpt2
   config:
-    use_pp: true
     use_meta_device: true
     use_weight_tying: false
     sample_key: ${settings.referencing_keys.sample_key}

--- a/tests/fsdp2_parallelization/pipeline_parallelism/configs/config_lorem_ipsum_long_fsdp2_pp_fwd_bwd_pass.yaml
+++ b/tests/fsdp2_parallelization/pipeline_parallelism/configs/config_lorem_ipsum_long_fsdp2_pp_fwd_bwd_pass.yaml
@@ -16,7 +16,7 @@ settings:
 
 loss_fn:
   component_key: loss
-  variant_key: clm_cross_entropy_loss_pp
+  variant_key: clm_cross_entropy_loss
   config:
     target_key: ${settings.referencing_keys.target_key}
     prediction_key: ${settings.referencing_keys.prediction_key}
@@ -129,7 +129,6 @@ model_raw:
   component_key: model
   variant_key: gpt2
   config:
-    use_pp: true
     use_meta_device: true
     use_weight_tying: false
     sample_key: ${settings.referencing_keys.sample_key}

--- a/tests/fsdp2_parallelization/pipeline_parallelism/test_pp_fwd_bwd_pass.py
+++ b/tests/fsdp2_parallelization/pipeline_parallelism/test_pp_fwd_bwd_pass.py
@@ -120,8 +120,9 @@ class TestPipelineParallelism:
             fsdp2_loss = self._forward_step_without_pp(inputs, targets)
 
             if is_last_pp_stage:
-                print(f"Loss with PP: {loss_pp.item()}, Loss without PP: {fsdp2_loss.item()}")
-                assert torch.allclose(loss_pp, fsdp2_loss, atol=1e-6, rtol=1e-5), "Losses do not match"
+                assert torch.allclose(
+                    loss_pp, fsdp2_loss, atol=1e-6, rtol=1e-5
+                ), f"Losses do not match.\nLoss with PP: {loss_pp.item()}, Loss without PP: {fsdp2_loss.item()}"
 
     def _forward_step_with_pp(
         self, pp_model_config_path: Path, inputs: torch.Tensor, targets: torch.Tensor

--- a/tests/fsdp2_parallelization/pipeline_parallelism/test_pp_fwd_bwd_pass.py
+++ b/tests/fsdp2_parallelization/pipeline_parallelism/test_pp_fwd_bwd_pass.py
@@ -120,6 +120,7 @@ class TestPipelineParallelism:
             fsdp2_loss = self._forward_step_without_pp(inputs, targets)
 
             if is_last_pp_stage:
+                print(f"Loss with PP: {loss_pp.item()}, Loss without PP: {fsdp2_loss.item()}")
                 assert torch.allclose(loss_pp, fsdp2_loss, atol=1e-6, rtol=1e-5), "Losses do not match"
 
     def _forward_step_with_pp(


### PR DESCRIPTION
# What does this PR do?

- Issue: Dicts, as used in modalities as model/loss inputs and outputs, are not supported in the torch pp code.
  - Reason: Direct GPU to GPU communication
  - See: https://github.com/pytorch/pytorch/issues/159711
  - Workaround: Overloaded corresponding forward() and __call__() methods to allow direct tensor input and output.
- Issue: Loss accumulation (for logging) needs to use DP world size in stead of total world size (also TP and CP?)
  - Solution:
    - For the averaged loss we only increment the batch count on the last stages of a PP schedule.
    - For the current batch loss we added the dp world size, computed from the device mesh, to the Trainer class.
- Issue: Due to a Bug in PyTorch we cannot evaluate before training begin.
  - Workaround: Disabled eval before training
  - Solution: Issue and PR opened for PyTorch 2.9
  - See: https://github.com/pytorch/pytorch/issues/162822
- Issue: Normal distributed dataloader/sampler use would loose batches
  - Solution: Use (Resumable)DistributedMultiDimSamplerConfig
  - TODO: Implement DistributedMultiDimSamplerConfig for eval dataloader
  - TODO??: Remove data_parallel_key param from SamplerFactory.create_resumable_distributed_multi_dim_sampler()
    - Instead use BOTH ParallelismDegrees.DP_REPLICATE and ParallelismDegrees.DP_SHARD (multiplied)
- Issue: Gradient clipping needs to sync over all stages
  - Solution: Implemented same procedure using all_reduce() as in TorchTitan.
  - Torch Issue: https://github.com/pytorch/pytorch/issues/162638
  - TorchTitan implementation: https://github.com/pytorch/torchtitan/blob/b291ad662493b63d25b038a30a915082d3617baf/torchtitan/distributed/utils.py#L298
- Issue: Instead of calling forward() and backward() on the model and executing the loss_fct(), PP requires to call step() on the pipeline schedule.
  - Solution: Integrated scheduled pipeline into Trainer and Evaluator
- Note: Weight tying is currently not supported
- Question: Do we need to consider something regarding model init so that all corresponding model copies are initialized the same?
  - I.e.: How can we assure that parallel stages are initialized the same?
  - Other way around: Will stages containing similar model parts be initialized the same?
  - Answer: Since we first build that PP stages and then the FSDP2 parallelization and then init, this is fine.
  - Follow up question: What happens, if we use full replica data parallelization?
- Issue: Want to compare non-PP forward pass with PP forward pass in unit test
  - Goal: Compare losses
  - Solution: Added a non-PP config used to compute a comparison loss
  - Issue: Need non-PP forward pass loss on all ranks that contain a last stage of the PP forward pass.
    - Solution: Run a normal FSDP2 forward pass on all ranks and ignore the output on non-last stage ranks.
	- Remark: Running the FSDP2 pass only on the last stage ranks led to hanging. This might be a known issue with FSDP2.
  - Issue: Need the model to effectively compute the same forward pass.
    - Solution:
	  - In the test config, run model model initialization before sharding/staging (don't do this in a real training!).
	  - Fix torch seed before each initialization.
	  - Fix torch seed before generating each input sequence. Note that we thus have identical data parallel batches.
  - TODO: Numerical instability can still be observed and needs to be investigated further (in FSDP only runs as well).
- TODO: TP + PP
  - Issue: What is the correct sharding/staging order?
    - Solution: 1. PP 2. TP 3. FSDP
  - Issue: TP initialization modifies the layers of the model and runs into problems if those have been deleted for PP.
    - Solution: Adapted TP code to be able to handle missing/None layers.
- TODO?: MFU
- TODO: Flash attention not installable with PyTorch 2.9 nightly?
- TODO: Write more tests.
  - Backwards test using gradient norm to compare to normal FSDP2 run
- TODO: CLean up, in particular type hints and doc strings.

## Checklist before submitting final PR
- [ ] My PR is minimal and addresses one issue in isolation
- [ ] I have merged the latest version of the target branch into this feature branch
- [ ] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [ ] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)