### PR TITLE
3 b training prep

### DIFF
--- a/src/modalities/checkpointing/fsdp/fsdp_checkpoint_loading.py
+++ b/src/modalities/checkpointing/fsdp/fsdp_checkpoint_loading.py
@@ -103,17 +103,18 @@ class FSDP1CheckpointLoading(FSDP1CheckpointLoadingIF):
 class DCPCheckpointLoading(DistributedCheckpointLoadingIF):
     """Distributed checkpoint loading interface for loading PyTorch models and optimizer checkpoints."""
 
-    def __init__(self, global_rank: int):
+    def __init__(self, global_rank: int, allow_partial_load: bool = False):
         """
         Initializes the DCPCheckpointLoading object.
 
         Args:
             global_rank (int): The global rank of the process.
-
+            allow_partial_load (bool, optional): Whether to allow partial loading of the checkpoint. Defaults to True.
         Returns:
             None
         """
         self._global_rank = global_rank
+        self._allow_partial_load = allow_partial_load
 
     @torch.no_grad()
     def load_checkpoint_(self, app_state: AppState, checkpoint_dir_path: Path):
@@ -129,5 +130,6 @@ class DCPCheckpointLoading(DistributedCheckpointLoadingIF):
         dcp.load(
             state_dict={"app": app_state},
             checkpoint_id=checkpoint_dir_path,
+            planner=dcp.DefaultLoadPlanner(allow_partial_load=self._allow_partial_load),
         )
         get_logger().info(f"Distributed checkpoint loaded on rank {self._global_rank}.")

--- a/src/modalities/checkpointing/fsdp/fsdp_checkpoint_loading.py
+++ b/src/modalities/checkpointing/fsdp/fsdp_checkpoint_loading.py
@@ -109,7 +109,7 @@ class DCPCheckpointLoading(DistributedCheckpointLoadingIF):
 
         Args:
             global_rank (int): The global rank of the process.
-            allow_partial_load (bool, optional): Whether to allow partial loading of the checkpoint. Defaults to True.
+            allow_partial_load (bool, optional): Whether to allow partial loading of the checkpoint. Defaults to False.
         Returns:
             None
         """

--- a/src/modalities/checkpointing/stateful/app_state.py
+++ b/src/modalities/checkpointing/stateful/app_state.py
@@ -66,6 +66,13 @@ class AppState(Stateful):
         else:
             self._components_to_load = components_to_load
 
+        invalid_components = [c for c in self._components_to_load if not isinstance(c, StatefulComponents)]
+        if invalid_components:
+            raise ValueError(
+                f"components_to_load must only contain StatefulComponents, but got invalid entries: "
+                f"{invalid_components}"
+            )
+
     @property
     def is_loaded(self) -> bool:
         """Returns whether the state dict has been loaded.

--- a/src/modalities/checkpointing/stateful/app_state.py
+++ b/src/modalities/checkpointing/stateful/app_state.py
@@ -37,7 +37,11 @@ class AppState(Stateful):
     """
 
     def __init__(
-        self, model: nn.Module | list[nn.Module], optimizer: Optimizer, lr_scheduler: Optional[LRScheduler] = None
+        self,
+        model: nn.Module | list[nn.Module],
+        optimizer: Optimizer,
+        lr_scheduler: Optional[LRScheduler] = None,
+        components_to_load: list[StatefulComponents] | None = None,
     ):
         """Initializes the AppState object.
 
@@ -46,11 +50,21 @@ class AppState(Stateful):
                 a non-sharded model, FSDP1 or FSDP2 model.
             optimizer (Optimizer): The optimizer can be either a non-sharded optimizer, FSDP1 or FSDP2 optimizer.
             lr_scheduler (Optional[LRScheduler], optional): The lr scheduler used during training. Defaults to None.
+            components_to_load (list[StatefulComponents] | None, optional): The list of components to load from the
+                checkpoint. If None, all components are loaded. Defaults to None.
         """
         self._model_parts = list(model) if isinstance(model, list) else [model]
         self._optimizer = optimizer
         self._lr_scheduler = lr_scheduler
         self._is_loaded = False
+
+        # policy for which components to load from the checkpoint. If None, defaults to loading all components.
+        if components_to_load is None:
+            self._components_to_load = [StatefulComponents.MODEL, StatefulComponents.OPTIMIZER]
+            if lr_scheduler is not None:
+                self._components_to_load.append(StatefulComponents.LR_SCHEDULER)
+        else:
+            self._components_to_load = components_to_load
 
     @property
     def is_loaded(self) -> bool:
@@ -106,12 +120,14 @@ class AppState(Stateful):
                 "Cannot call load_state_dict twice on the same AppState object. " "State dict has already been loaded."
             )
 
-        ModelStateRetriever.load_state_dict_(app_state=self, state_dict=state_dict[StatefulComponents.MODEL.value])
-        OptimizerStateRetriever.load_state_dict_(
-            app_state=self,
-            state_dict=state_dict[StatefulComponents.OPTIMIZER.value],
-        )
-        if self._lr_scheduler is not None:
+        if StatefulComponents.MODEL in self._components_to_load:
+            ModelStateRetriever.load_state_dict_(app_state=self, state_dict=state_dict[StatefulComponents.MODEL.value])
+        if StatefulComponents.OPTIMIZER in self._components_to_load:
+            OptimizerStateRetriever.load_state_dict_(
+                app_state=self,
+                state_dict=state_dict[StatefulComponents.OPTIMIZER.value],
+            )
+        if self._lr_scheduler is not None and StatefulComponents.LR_SCHEDULER in self._components_to_load:
             LRSchedulerStateRetriever.load_state_dict_(
                 app_state=self, state_dict=state_dict[StatefulComponents.LR_SCHEDULER.value]
             )

--- a/src/modalities/checkpointing/stateful/app_state_factory.py
+++ b/src/modalities/checkpointing/stateful/app_state_factory.py
@@ -47,7 +47,7 @@ class AppStateFactory:
     def get_dcp_checkpointed_app_state_(
         raw_app_state: AppState,
         checkpoint_dir_path: Path,
-        allow_partial_load: bool = True,
+        allow_partial_load: bool = False,
     ) -> AppState:
         """Loads the checkpointed state dict into the raw AppState object
         (i.e., non-checkpoint loaded AppState) in-place.
@@ -56,7 +56,7 @@ class AppStateFactory:
             raw_app_state (AppState): The raw AppState object. Its ``components_to_load`` policy
                 determines which components are restored.
             checkpoint_dir_path (Path): The path to the checkpoint directory.
-            allow_partial_load (bool, optional): Whether to allow partial loading of the checkpoint. Defaults to True.
+            allow_partial_load (bool, optional): Whether to allow partial loading of the checkpoint. Defaults to False.
 
         Raises:
             RuntimeError: Raises an error if the state dict has already been loaded.

--- a/src/modalities/checkpointing/stateful/app_state_factory.py
+++ b/src/modalities/checkpointing/stateful/app_state_factory.py
@@ -7,7 +7,7 @@ from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
 
 from modalities.checkpointing.fsdp.fsdp_checkpoint_loading import DCPCheckpointLoading
-from modalities.checkpointing.stateful.app_state import AppState
+from modalities.checkpointing.stateful.app_state import AppState, StatefulComponents
 
 
 class AppStateFactory:
@@ -15,7 +15,10 @@ class AppStateFactory:
 
     @staticmethod
     def get_raw_app_state(
-        model: nn.Module | list[nn.Module], optimizer: Optimizer, lr_scheduler: Optional[LRScheduler] = None
+        model: nn.Module | list[nn.Module],
+        optimizer: Optimizer,
+        lr_scheduler: Optional[LRScheduler] = None,
+        components_to_load: list[StatefulComponents] | None = None,
     ) -> AppState:
         """Creates a new (non-checkpoint loaded) AppState object from an instantiated
         model, optimizer, and optional learning rate scheduler.
@@ -25,11 +28,19 @@ class AppStateFactory:
                 a non-sharded model, FSDP1 or FSDP2 model.
             optimizer (Optimizer): The optimizer can be either a non-sharded optimizer, FSDP1 or FSDP2 optimizer.
             lr_scheduler (Optional[LRScheduler], optional): Lr scheduler used during training. Defaults to None.
+            components_to_load (list[StatefulComponents] | None, optional): Subset of components that should
+                be restored from a checkpoint when ``load_state_dict`` is later invoked. If None, all
+                available components are loaded. Defaults to None.
 
         Returns:
             AppState: The AppState object.
         """
-        app_state = AppState(model=model, optimizer=optimizer, lr_scheduler=lr_scheduler)
+        app_state = AppState(
+            model=model,
+            optimizer=optimizer,
+            lr_scheduler=lr_scheduler,
+            components_to_load=components_to_load,
+        )
         return app_state
 
     @staticmethod
@@ -41,7 +52,8 @@ class AppStateFactory:
         (i.e., non-checkpoint loaded AppState) in-place.
 
         Args:
-            raw_app_state (AppState): The raw AppState object.
+            raw_app_state (AppState): The raw AppState object. Its ``components_to_load`` policy
+                determines which components are restored.
             checkpoint_dir_path (Path): The path to the checkpoint directory.
 
         Raises:
@@ -52,8 +64,9 @@ class AppStateFactory:
         """
         if raw_app_state.is_loaded:
             raise RuntimeError(
-                "Cannot call load_state_dict twice on the same AppState object. " "State dict has already been loaded."
+                "Cannot call load_state_dict twice on the same AppState object. State dict has already been loaded."
             )
+
         cp_loading = DCPCheckpointLoading(global_rank=dist.get_rank())
         cp_loading.load_checkpoint_(app_state=raw_app_state, checkpoint_dir_path=checkpoint_dir_path)
         return raw_app_state

--- a/src/modalities/checkpointing/stateful/app_state_factory.py
+++ b/src/modalities/checkpointing/stateful/app_state_factory.py
@@ -47,6 +47,7 @@ class AppStateFactory:
     def get_dcp_checkpointed_app_state_(
         raw_app_state: AppState,
         checkpoint_dir_path: Path,
+        allow_partial_load: bool = True,
     ) -> AppState:
         """Loads the checkpointed state dict into the raw AppState object
         (i.e., non-checkpoint loaded AppState) in-place.
@@ -55,6 +56,7 @@ class AppStateFactory:
             raw_app_state (AppState): The raw AppState object. Its ``components_to_load`` policy
                 determines which components are restored.
             checkpoint_dir_path (Path): The path to the checkpoint directory.
+            allow_partial_load (bool, optional): Whether to allow partial loading of the checkpoint. Defaults to True.
 
         Raises:
             RuntimeError: Raises an error if the state dict has already been loaded.
@@ -67,6 +69,6 @@ class AppStateFactory:
                 "Cannot call load_state_dict twice on the same AppState object. State dict has already been loaded."
             )
 
-        cp_loading = DCPCheckpointLoading(global_rank=dist.get_rank())
+        cp_loading = DCPCheckpointLoading(global_rank=dist.get_rank(), allow_partial_load=allow_partial_load)
         cp_loading.load_checkpoint_(app_state=raw_app_state, checkpoint_dir_path=checkpoint_dir_path)
         return raw_app_state

--- a/src/modalities/config/config.py
+++ b/src/modalities/config/config.py
@@ -11,6 +11,7 @@ from transformers import GPT2Tokenizer as GPT2TokenizerFast
 from transformers import LlamaTokenizer as LlamaTokenizerFast
 from typing_extensions import deprecated
 
+from modalities.checkpointing.stateful.app_state import StatefulComponents
 from modalities.config.lookup_enum import LookupEnum
 from modalities.config.pydantic_if_types import (
     PydanticAppStateType,
@@ -382,6 +383,7 @@ class RawAppStateConfig(BaseModel):
     model: PydanticPytorchModuleOrListType
     optimizer: PydanticOptimizerIFType
     lr_scheduler: Optional[PydanticLRSchedulerIFType] = None
+    components_to_load: Optional[list[StatefulComponents]] = None
 
 
 class DCPAppStateConfig(BaseModel):

--- a/src/modalities/config/config.py
+++ b/src/modalities/config/config.py
@@ -34,6 +34,7 @@ from modalities.config.pydantic_if_types import (
     PydanticTokenizerIFType,
 )
 from modalities.config.utils import parse_torch_device
+from modalities.models.weight_tying import has_tied_word_embeddings
 from modalities.running_env.env_utils import (
     FSDP2MixedPrecisionSettings,
     MixedPrecisionSettings,
@@ -340,6 +341,13 @@ class GPT2ModelTPConfig(BaseModel):
         if ParallelismDegrees.DP_REPLICATE.value in mesh_dim_names:
             # TorchTitan uses replicate (i.e, plain DP) to combine DP with TP.
             raise ValueError("data_parallel_replicate_degree > 1 cannot be used with Tensor Parallelism.")
+        return self
+
+    @model_validator(mode="after")
+    def validate_untied_word_embeddings(self) -> "GPT2ModelTPConfig":
+        models = self.model if isinstance(self.model, list) else [self.model]
+        if any(has_tied_word_embeddings(model) for model in models):
+            raise ValueError("Tied word embeddings are not supported with Tensor Parallelism.")
         return self
 
 

--- a/src/modalities/config/config.py
+++ b/src/modalities/config/config.py
@@ -126,11 +126,6 @@ class FSDP1CheckpointLoadingConfig(BaseModel):
         return parse_enum_by_name(name=name, enum_type=ShardingStrategy)
 
 
-# class DCPCheckpointLoadingConfig(BaseModel):
-#     global_rank: Annotated[int, Field(strict=True, ge=0)]
-#     allow_partial_load: bool = True
-
-
 class FSDP1CheckpointSavingConfig(BaseModel):
     checkpoint_path: Path
     global_rank: Annotated[int, Field(strict=True, ge=0)]

--- a/src/modalities/config/config.py
+++ b/src/modalities/config/config.py
@@ -125,8 +125,9 @@ class FSDP1CheckpointLoadingConfig(BaseModel):
         return parse_enum_by_name(name=name, enum_type=ShardingStrategy)
 
 
-class DCPCheckpointLoadingConfig(BaseModel):
-    global_rank: Annotated[int, Field(strict=True, ge=0)]
+# class DCPCheckpointLoadingConfig(BaseModel):
+#     global_rank: Annotated[int, Field(strict=True, ge=0)]
+#     allow_partial_load: bool = True
 
 
 class FSDP1CheckpointSavingConfig(BaseModel):
@@ -389,6 +390,7 @@ class RawAppStateConfig(BaseModel):
 class DCPAppStateConfig(BaseModel):
     raw_app_state: PydanticAppStateType
     checkpoint_dir_path: Path
+    allow_partial_load: bool = False
 
 
 class PreTrainedHFTokenizerConfig(BaseModel):

--- a/src/modalities/models/gpt2/gpt2_model.py
+++ b/src/modalities/models/gpt2/gpt2_model.py
@@ -938,6 +938,12 @@ class GPT2LLM(NNModel):
                 self.transformer.lm_head.weight
             )  # https://paperswithcode.com/method/weight-tying
 
+    @property
+    def has_tied_word_embeddings(self) -> bool:
+        token_embedding_weight = getattr(self.transformer.wte, "weight", None)
+        lm_head_weight = getattr(self.transformer.lm_head, "weight", None)
+        return token_embedding_weight is not None and token_embedding_weight is lm_head_weight
+
     @overload
     def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """

--- a/src/modalities/models/gpt2/llama3_like_initialization.py
+++ b/src/modalities/models/gpt2/llama3_like_initialization.py
@@ -23,7 +23,7 @@ class Llama3Initializer(ModelInitializationIF):
     Follows weight initialization distributions and parameterization for Llama3 as described in TorchTitan.
     """
 
-    def __init__(self, num_layers: int, n_embd: int, depth_init: bool) -> None:
+    def __init__(self, num_layers: int, n_embd: int, depth_init: bool, use_weight_tying: bool) -> None:
         """
         Initializes the Llama3Initializer.
         Args:
@@ -39,16 +39,6 @@ class Llama3Initializer(ModelInitializationIF):
         self.regex_to_init = {
             # embedding weights
             r"transformer\.wte\.weight": (nn.init.normal_, {"mean": 0.0, "std": 1}),
-            # lm head weights
-            r"transformer\.lm_head\.weight": (
-                trunc_normal_,
-                {
-                    "mean": 0.0,
-                    "std": 1 / math.sqrt(n_embd),
-                    "a": -3 / math.sqrt(n_embd),
-                    "b": 3 / math.sqrt(n_embd),
-                },
-            ),
             # qkv projections
             r"transformer\.h\.\d+\.attn\.(q_attn|k_attn|v_attn)\.weight": (
                 trunc_normal_,
@@ -97,6 +87,17 @@ class Llama3Initializer(ModelInitializationIF):
                 },
             ),
         }
+        if not use_weight_tying:
+            # lm head weights
+            self.regex_to_init[r"transformer\.lm_head\.weight"] = (
+                trunc_normal_,
+                {
+                    "mean": 0.0,
+                    "std": 1 / math.sqrt(n_embd),
+                    "a": -3 / math.sqrt(n_embd),
+                    "b": 3 / math.sqrt(n_embd),
+                },
+            )
 
     def initialize_in_place(self, model: nn.Module):
         self._init_by_fqn_regex(model, self.regex_to_init)

--- a/src/modalities/models/gpt2/llama3_like_initialization.py
+++ b/src/modalities/models/gpt2/llama3_like_initialization.py
@@ -15,6 +15,7 @@ logger = get_logger(name="llama3 initialization")
 class Llama3InitializerConfig(BaseModel):
     num_layers: Annotated[int, Field(strict=True, gt=0)]
     n_embd: Annotated[int, Field(strict=True, gt=0)]
+    use_weight_tying: bool
     depth_init: bool = True
 
 

--- a/src/modalities/models/model.py
+++ b/src/modalities/models/model.py
@@ -46,6 +46,11 @@ class NNModel(nn.Module):
         """
         return self._weight_decay_groups
 
+    @property
+    def has_tied_word_embeddings(self) -> bool:
+        """Whether the model currently uses tied token embedding and output weights."""
+        return False
+
     @abstractmethod
     def forward(self, inputs: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """

--- a/src/modalities/models/parallelism/pipeline_parallelism_configs.py
+++ b/src/modalities/models/parallelism/pipeline_parallelism_configs.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from modalities.config.pydantic_if_types import (
     PydanticDeviceMeshIFType,
@@ -11,6 +11,7 @@ from modalities.config.pydantic_if_types import (
     PydanticStagesGeneratorType,
 )
 from modalities.models.parallelism.pipeline_parallelism import PipelineSelectionTypes
+from modalities.models.weight_tying import has_tied_word_embeddings
 from modalities.utils.deprecated_alias import add_deprecated_alias
 
 
@@ -25,6 +26,12 @@ class StagedPipelineConfig(BaseModel):
     local_rank: Annotated[int, Field(strict=True, ge=0)]
     pp_schedule_name: str
     num_layers_per_stage: Annotated[int, Field(strict=True, ge=1)]
+
+    @model_validator(mode="after")
+    def validate_untied_word_embeddings(self) -> "StagedPipelineConfig":
+        if has_tied_word_embeddings(self.whole_model):
+            raise ValueError("Tied word embeddings are not supported with Pipeline Parallelism.")
+        return self
 
 
 class ScheduledPipelineConfig(BaseModel):

--- a/src/modalities/models/weight_tying.py
+++ b/src/modalities/models/weight_tying.py
@@ -1,0 +1,11 @@
+import torch.nn as nn
+
+
+def has_tied_word_embeddings(model: nn.Module) -> bool:
+    model_has_tied_word_embeddings = getattr(model, "has_tied_word_embeddings", None)
+    if model_has_tied_word_embeddings is None:
+        raise TypeError(
+            f"{type(model).__name__} must define 'has_tied_word_embeddings' to be used with tied-embedding validation."
+        )
+
+    return bool(model_has_tied_word_embeddings)

--- a/src/modalities/registry/components.py
+++ b/src/modalities/registry/components.py
@@ -13,7 +13,7 @@ from modalities.checkpointing.checkpoint_saving_strategies import (
     SaveEveryKStepsCheckpointingStrategy,
     SaveKMostRecentCheckpointsStrategy,
 )
-from modalities.checkpointing.fsdp.fsdp_checkpoint_loading import DCPCheckpointLoading, FSDP1CheckpointLoading
+from modalities.checkpointing.fsdp.fsdp_checkpoint_loading import FSDP1CheckpointLoading
 from modalities.checkpointing.fsdp.fsdp_checkpoint_saving import DCPCheckpointSaving, FSDP1CheckpointSaving
 from modalities.checkpointing.stateful.app_state_factory import AppStateFactory
 from modalities.checkpointing.torch.torch_checkpoint_loading import TorchCheckpointLoading
@@ -29,7 +29,6 @@ from modalities.config.config import (
     ConstantLRSchedulerConfig,
     CosineAnnealingLRSchedulerConfig,
     DCPAppStateConfig,
-    DCPCheckpointLoadingConfig,
     DCPCheckpointSavingConfig,
     DebuggingEnrichedModelConfig,
     DistributedSamplerConfig,
@@ -358,7 +357,7 @@ COMPONENTS = [
     ComponentEntity("checkpoint_saving_execution", "dcp", DCPCheckpointSaving, DCPCheckpointSavingConfig),
     # checkpoint loading
     ComponentEntity("checkpoint_loading", "fsdp1", FSDP1CheckpointLoading, FSDP1CheckpointLoadingConfig),
-    ComponentEntity("checkpoint_loading", "dcp", DCPCheckpointLoading, DCPCheckpointLoadingConfig),
+    # ComponentEntity("checkpoint_loading", "dcp", DCPCheckpointLoading, DCPCheckpointLoadingConfig),
     ComponentEntity("checkpoint_loading", "torch", TorchCheckpointLoading, TorchCheckpointLoadingConfig),
     # Progress subscriber
     ComponentEntity(

--- a/tests/checkpointing/test_app_state_components_to_load.py
+++ b/tests/checkpointing/test_app_state_components_to_load.py
@@ -135,3 +135,28 @@ class TestComponentsToLoad:
 
         with pytest.raises(RuntimeError):
             app_state.load_state_dict(_make_state_dict())
+
+
+class TestComponentsToLoadValidation:
+    @pytest.mark.parametrize(
+        "invalid_components",
+        [
+            ["model"],
+            [StatefulComponents.MODEL, "optimizer"],
+            [StatefulComponents.MODEL.value],
+            [None],
+            [0],
+        ],
+    )
+    def test_non_stateful_components_raise_value_error(
+        self, model: nn.Module, optimizer: SGD, invalid_components: list
+    ) -> None:
+        with pytest.raises(ValueError, match="StatefulComponents"):
+            AppState(model=model, optimizer=optimizer, components_to_load=invalid_components)
+
+    def test_valid_components_do_not_raise(self, model: nn.Module, optimizer: SGD) -> None:
+        AppState(
+            model=model,
+            optimizer=optimizer,
+            components_to_load=[StatefulComponents.MODEL, StatefulComponents.OPTIMIZER],
+        )

--- a/tests/checkpointing/test_app_state_components_to_load.py
+++ b/tests/checkpointing/test_app_state_components_to_load.py
@@ -1,0 +1,137 @@
+from unittest.mock import MagicMock
+
+import pytest
+import torch.nn as nn
+from torch.optim import SGD
+from torch.optim.lr_scheduler import StepLR
+
+from modalities.checkpointing.stateful import app_state as app_state_module
+from modalities.checkpointing.stateful.app_state import AppState, StatefulComponents
+
+
+@pytest.fixture
+def model() -> nn.Module:
+    return nn.Linear(4, 2)
+
+
+@pytest.fixture
+def optimizer(model: nn.Module) -> SGD:
+    return SGD(model.parameters(), lr=0.1)
+
+
+@pytest.fixture
+def lr_scheduler(optimizer: SGD) -> StepLR:
+    return StepLR(optimizer, step_size=1)
+
+
+@pytest.fixture
+def patched_retrievers(monkeypatch: pytest.MonkeyPatch) -> dict[StatefulComponents, MagicMock]:
+    """Replace each retriever's ``load_state_dict_`` with a mock so we can assert which ones were invoked."""
+    mocks = {
+        StatefulComponents.MODEL: MagicMock(),
+        StatefulComponents.OPTIMIZER: MagicMock(),
+        StatefulComponents.LR_SCHEDULER: MagicMock(),
+    }
+    monkeypatch.setattr(app_state_module.ModelStateRetriever, "load_state_dict_", mocks[StatefulComponents.MODEL])
+    monkeypatch.setattr(
+        app_state_module.OptimizerStateRetriever, "load_state_dict_", mocks[StatefulComponents.OPTIMIZER]
+    )
+    monkeypatch.setattr(
+        app_state_module.LRSchedulerStateRetriever, "load_state_dict_", mocks[StatefulComponents.LR_SCHEDULER]
+    )
+    return mocks
+
+
+def _make_state_dict() -> dict:
+    return {
+        StatefulComponents.MODEL.value: {"model_payload": True},
+        StatefulComponents.OPTIMIZER.value: {"optimizer_payload": True},
+        StatefulComponents.LR_SCHEDULER.value: {"lr_scheduler_payload": True},
+    }
+
+
+class TestComponentsToLoad:
+    def test_default_without_lr_scheduler_loads_model_and_optimizer(
+        self, model: nn.Module, optimizer: SGD, patched_retrievers: dict[StatefulComponents, MagicMock]
+    ) -> None:
+        app_state = AppState(model=model, optimizer=optimizer)
+
+        app_state.load_state_dict(_make_state_dict())
+
+        patched_retrievers[StatefulComponents.MODEL].assert_called_once()
+        patched_retrievers[StatefulComponents.OPTIMIZER].assert_called_once()
+        patched_retrievers[StatefulComponents.LR_SCHEDULER].assert_not_called()
+        assert app_state.is_loaded
+
+    def test_default_with_lr_scheduler_loads_all_three(
+        self,
+        model: nn.Module,
+        optimizer: SGD,
+        lr_scheduler: StepLR,
+        patched_retrievers: dict[StatefulComponents, MagicMock],
+    ) -> None:
+        app_state = AppState(model=model, optimizer=optimizer, lr_scheduler=lr_scheduler)
+
+        app_state.load_state_dict(_make_state_dict())
+
+        patched_retrievers[StatefulComponents.MODEL].assert_called_once()
+        patched_retrievers[StatefulComponents.OPTIMIZER].assert_called_once()
+        patched_retrievers[StatefulComponents.LR_SCHEDULER].assert_called_once()
+
+    @pytest.mark.parametrize(
+        "selected",
+        [
+            [StatefulComponents.MODEL],
+            [StatefulComponents.OPTIMIZER],
+            [StatefulComponents.LR_SCHEDULER],
+            [StatefulComponents.MODEL, StatefulComponents.OPTIMIZER],
+            [StatefulComponents.MODEL, StatefulComponents.LR_SCHEDULER],
+            [],
+        ],
+    )
+    def test_explicit_selection_only_loads_chosen_components(
+        self,
+        model: nn.Module,
+        optimizer: SGD,
+        lr_scheduler: StepLR,
+        patched_retrievers: dict[StatefulComponents, MagicMock],
+        selected: list[StatefulComponents],
+    ) -> None:
+        app_state = AppState(model=model, optimizer=optimizer, lr_scheduler=lr_scheduler, components_to_load=selected)
+
+        app_state.load_state_dict(_make_state_dict())
+
+        for component, mock in patched_retrievers.items():
+            if component in selected:
+                mock.assert_called_once()
+            else:
+                mock.assert_not_called()
+
+    def test_lr_scheduler_in_components_but_no_scheduler_attached_is_skipped(
+        self, model: nn.Module, optimizer: SGD, patched_retrievers: dict[StatefulComponents, MagicMock]
+    ) -> None:
+        # Guards against the lr_scheduler branch firing when no scheduler is attached — the
+        # state_dict won't carry a scheduler entry, so the retriever must not be called.
+        app_state = AppState(
+            model=model,
+            optimizer=optimizer,
+            components_to_load=[StatefulComponents.MODEL, StatefulComponents.LR_SCHEDULER],
+        )
+
+        state_dict = _make_state_dict()
+        state_dict.pop(StatefulComponents.LR_SCHEDULER.value)
+
+        app_state.load_state_dict(state_dict)
+
+        patched_retrievers[StatefulComponents.MODEL].assert_called_once()
+        patched_retrievers[StatefulComponents.OPTIMIZER].assert_not_called()
+        patched_retrievers[StatefulComponents.LR_SCHEDULER].assert_not_called()
+
+    def test_double_load_raises(
+        self, model: nn.Module, optimizer: SGD, patched_retrievers: dict[StatefulComponents, MagicMock]
+    ) -> None:
+        app_state = AppState(model=model, optimizer=optimizer)
+        app_state.load_state_dict(_make_state_dict())
+
+        with pytest.raises(RuntimeError):
+            app_state.load_state_dict(_make_state_dict())

--- a/tests/test_weight_tying.py
+++ b/tests/test_weight_tying.py
@@ -1,6 +1,9 @@
 import pytest
 import torch.nn as nn
+from pydantic import ValidationError
+from torch.distributed.device_mesh import DeviceMesh
 
+from modalities.config.config import GPT2ModelTPConfig
 from modalities.models.components.layer_norms import LayerNormConfig
 from modalities.models.gpt2.gpt2_model import (
     GPT2LLM,
@@ -11,6 +14,10 @@ from modalities.models.gpt2.gpt2_model import (
     PositionTypes,
 )
 from modalities.models.model import ActivationType
+from modalities.models.parallelism.pipeline_parallelism_configs import StagedPipelineConfig
+from modalities.models.parallelism.stages_generator import GPT2LLMStagesGenerator
+from modalities.models.weight_tying import has_tied_word_embeddings
+from modalities.running_env.fsdp.device_mesh import ParallelismDegrees
 
 VOCAB_SIZE = 1000
 EMBEDDING_DIM = 64
@@ -79,9 +86,17 @@ def create_gpt2_model(use_weight_tying: bool) -> GPT2LLM:
     )
 
 
+def create_device_mesh_stub(*mesh_dim_names: str) -> DeviceMesh:
+    device_mesh = DeviceMesh.__new__(DeviceMesh)
+    device_mesh.mesh_dim_names = mesh_dim_names
+    return device_mesh
+
+
 @pytest.mark.parametrize("use_weight_tying", [True, False])
 def test_weight_tying_behavior(use_weight_tying):
     model = create_gpt2_model(use_weight_tying)
+    assert model.has_tied_word_embeddings is use_weight_tying
+
     if use_weight_tying:
         assert (
             model.transformer.wte.weight is model.transformer.lm_head.weight
@@ -118,3 +133,52 @@ def test_weight_tying_named_parameters(use_weight_tying):
         assert (
             "transformer.lm_head.weight" in named_params
         ), "transformer.lm_head.weight should appear in named_parameters when weight tying is not used."
+
+
+def test_has_tied_word_embeddings_requires_model_capability():
+    with pytest.raises(TypeError, match="must define 'has_tied_word_embeddings'"):
+        has_tied_word_embeddings(nn.Linear(1, 1))
+
+
+def test_tp_config_rejects_tied_word_embeddings():
+    model = create_gpt2_model(use_weight_tying=True)
+    device_mesh = create_device_mesh_stub(ParallelismDegrees.TP.value)
+
+    with pytest.raises(ValidationError, match="Tied word embeddings are not supported with Tensor Parallelism"):
+        GPT2ModelTPConfig(model=model, device_mesh=device_mesh)
+
+
+def test_tp_config_allows_untied_word_embeddings():
+    model = create_gpt2_model(use_weight_tying=False)
+    device_mesh = create_device_mesh_stub(ParallelismDegrees.TP.value)
+
+    GPT2ModelTPConfig(model=model, device_mesh=device_mesh)
+
+
+def test_pp_config_rejects_tied_word_embeddings():
+    model = create_gpt2_model(use_weight_tying=True)
+    device_mesh = create_device_mesh_stub(ParallelismDegrees.PP.value)
+
+    with pytest.raises(ValidationError, match="Tied word embeddings are not supported with Pipeline Parallelism"):
+        StagedPipelineConfig(
+            whole_model=model,
+            stages_generator=GPT2LLMStagesGenerator(num_model_layers=model.n_layer),
+            device_mesh=device_mesh,
+            local_rank=0,
+            pp_schedule_name="gpipe",
+            num_layers_per_stage=1,
+        )
+
+
+def test_pp_config_allows_untied_word_embeddings():
+    model = create_gpt2_model(use_weight_tying=False)
+    device_mesh = create_device_mesh_stub(ParallelismDegrees.PP.value)
+
+    StagedPipelineConfig(
+        whole_model=model,
+        stages_generator=GPT2LLMStagesGenerator(num_model_layers=model.n_layer),
+        device_mesh=device_mesh,
+        local_rank=0,
+        pp_schedule_name="gpipe",
+        num_layers_per_stage=1,
+    )


### PR DESCRIPTION
# What does this PR do?

This PR prepares the 3B training path by tightening weight-tying behavior for parallel training and by making DCP checkpoint restores more flexible.

## General Changes
* Add selective `AppState` component loading so checkpoint restore can load only the model, optimizer, and/or LR scheduler as needed.
* Thread `components_to_load` and `allow_partial_load` through the app-state factory and DCP checkpoint loading path.
* Add `has_tied_word_embeddings` model capability checks and centralize tied-embedding validation helpers.
* Reject tied word embeddings for Tensor Parallelism and Pipeline Parallelism configs.
* Update the Llama3-like initializer so `lm_head` is only initialized separately when weight tying is disabled.
* Expose `has_tied_word_embeddings` on GPT-2 models and add a default implementation on the base model class.
* Add tests covering selective checkpoint component loading and tied-embedding validation behavior.

## Breaking Changes
* Tensor Parallelism and Pipeline Parallelism configs now fail validation when tied word embeddings are enabled.
* DCP app-state loading config now includes `allow_partial_load`, which changes how partial checkpoint restores can be configured explicitly.

## Checklist before submitting final PR
- [ ] My PR is minimal and addresses one issue in isolation
- [ ] I have merged the latest version of the target branch into this feature branch
- [ ] I have reviewed my own code w.r.t. correct implementation, missing type hints, proper documentation, etc.
- [ ] I have run a sample config for model training
- [ ] I have checked that all tests run through (`python tests/tests.py`)
- [ ] I have updated the internal changelog (`CHANGELOG_DEV.md`)